### PR TITLE
add skeletal pmix.so plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = t
+SUBDIRS = src/shell/plugins t
 
 EXTRA_DIST = \
 	NEWS.md \

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,7 @@ AC_SUBST(fluxplugin_ldflags)
 ##
 AC_CONFIG_FILES( \
   Makefile \
+  src/shell/plugins/Makefile \
   t/Makefile \
   t/sharness.d/00-setup.sh \
   t/src/Makefile \

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -1,0 +1,30 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+AM_CPPFLAGS = \
+	-I$(top_srcdir)
+
+shell_plugin_LTLIBRARIES = \
+	pmix.la
+
+pmix_la_SOURCES = \
+	main.c
+pmix_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(FLUX_CORE_CFLAGS) \
+	$(FLUX_IDSET_CFLAGS) \
+	$(FLUX_HOSTLIST_CFLAGS) \
+	$(PMIX_CFLAGS) \
+	$(JANSSON_CFLAGS)
+pmix_la_LIBADD = \
+	$(FLUX_CORE_LIBS) \
+	$(PMIX_LIBS) \
+	$(FLUX_IDSET_LIBS) \
+	$(FLUX_HOSTLIST_LIBS) \
+	$(JANSSON_LIBS)
+pmix_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(fluxplugin_ldflags) \
+	-module

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -1,0 +1,182 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* main.c - main entry point for flux pmix shell plugin
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/shell.h>
+
+#include <pmix_server.h>
+#include <pmix.h>
+
+struct px {
+    flux_shell_t *shell;
+    flux_jobid_t id;
+    char nspace[PMIX_MAX_NSLEN + 1];
+    int shell_rank;
+    int local_nprocs;
+    int total_nprocs;
+};
+
+static void px_destroy (struct px *px)
+{
+    if (px) {
+        int rc;
+        int saved_errno = errno;
+        if ((rc = PMIx_server_finalize ()))
+            shell_warn ("PMIx_server_finalize: %s", PMIx_Error_string (rc));
+        free (px);
+        errno = saved_errno;
+    }
+}
+
+static int px_init (flux_plugin_t *p,
+                    const char *topic,
+                    flux_plugin_arg_t *arg,
+                    void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct px *px;
+    int rc;
+    pmix_info_t info = { 0 };
+    const char *s;
+
+    if (!(px = calloc (1, sizeof (*px)))
+        || flux_plugin_aux_set (p, "px", px, (flux_free_f)px_destroy) < 0) {
+        px_destroy (px);
+        return -1;
+    }
+    px->shell = shell;
+
+    if (flux_shell_info_unpack (shell,
+                                "{s:I s:i}",
+                                "jobid", &px->id,
+                                "rank", &px->shell_rank) < 0)
+        return -1;
+    if (flux_job_id_encode (px->id, "f58", px->nspace, sizeof (px->nspace)) < 0)
+        return -1;
+    if (flux_shell_rank_info_unpack (shell,
+                                     px->shell_rank,
+                                     "{s:i}",
+                                     "ntasks",
+                                     &px->local_nprocs) < 0)
+        return -1;
+    if (flux_shell_jobspec_info_unpack (shell,
+                                        "{s:i}",
+                                        "ntasks",
+                                        &px->total_nprocs) < 0)
+        return -1;
+
+    if ((rc = PMIx_server_init (NULL, NULL, 0)) != PMIX_SUCCESS) {
+        shell_warn ("PMIx_server_init: %s", PMIx_Error_string (rc));
+        return -1;
+    }
+
+    strncpy (info.key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+    info.value.type = PMIX_UINT32;
+    info.value.data.uint32 = px->total_nprocs;
+
+    if ((rc = PMIx_server_register_nspace (px->nspace,
+                                           px->local_nprocs,
+                                           &info,
+                                           1,
+                                           NULL,
+                                           NULL)) != PMIX_OPERATION_SUCCEEDED) {
+        shell_warn ("PMIx_server_register_nspace: %s", PMIx_Error_string (rc));
+        return -1;
+    }
+
+    return 0;
+}
+
+static int px_task_init (flux_plugin_t *p,
+                         const char *topic,
+                         flux_plugin_arg_t *args,
+                         void *arg)
+{
+    flux_shell_t *shell;
+    struct px *px;
+    flux_shell_task_t *task;
+    flux_cmd_t *cmd;
+    pmix_proc_t proc = { 0 };
+    char **env = NULL;
+    int rank;
+    int rc;
+
+    if (!(shell = flux_plugin_get_shell (p))
+        || !(px = flux_plugin_aux_get (p, "px"))
+        || !(task = flux_shell_current_task (shell))
+        || !(cmd = flux_shell_task_cmd (task))
+        || flux_shell_task_info_unpack (task, "{s:i}", "rank", &rank) < 0)
+        return -1;
+
+    proc.rank = rank;
+    strncpy (proc.nspace, px->nspace, PMIX_MAX_NSLEN);
+
+    /* Fetch this task's PMIX_* environment and add to task's
+     * subprocess command.
+     */
+    if ((rc = PMIx_server_setup_fork (&proc, &env)) != PMIX_SUCCESS) {
+        shell_warn ("PMIx_server_setup_fork %s.%d: %s",
+                    proc.nspace,
+                    proc.rank,
+                    PMIx_Error_string (rc));
+        return -1;
+    }
+    if (env) {
+        int i;
+        for (i = 0; env[i] != NULL; i++) {
+            char *name = env[i];
+            char *value = strchr (name, '=');
+            if (value)
+                *value++ = '\0';
+            if (flux_cmd_setenvf (cmd, 1, name, "%s", value) < 0) {
+                shell_warn ("flux_cmd_setenvf %s failed", name);
+                return -1;
+            }
+        }
+        free (env);
+    }
+
+    /* Allow task rank and uid/gid (same as ours) to connect to
+     * the server tcp port.
+     * SECURITY: By default openpmix uses its "native" authentication method
+     * which we should verify does some something meaningful to prevent other
+     * users from claiming to be this user on connect.
+     */
+    if ((rc = PMIx_server_register_client (&proc,
+                                           getuid (),
+                                           getgid (),
+                                           NULL,
+                                           NULL,
+                                           NULL)) != PMIX_OPERATION_SUCCEEDED) {
+        shell_warn ("PMIx_server_register_client %s.%d: %s",
+                    proc.nspace,
+                    proc.rank,
+                    PMIx_Error_string (rc));
+        return -1;
+    }
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_set_name (p, "pmix") < 0
+        || flux_plugin_add_handler (p, "shell.init", px_init, NULL) < 0
+        || flux_plugin_add_handler (p, "task.init",  px_task_init, NULL) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -24,7 +24,8 @@ clean-local:
 # This list is included in both TESTS and dist_check_SCRIPTS.
 TESTSCRIPTS = \
 	t0000-sharness.t \
-	t0001-ompi-sanity.t
+	t0001-ompi-sanity.t \
+	t0002-basic.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -11,6 +11,7 @@ AM_CPPFLAGS = \
 check_PROGRAMS = \
 	barrier \
 	bizcard \
+	version \
 	mpi_hello \
 	mpi_version \
 	mpi_abort
@@ -33,6 +34,10 @@ barrier_LDADD = $(test_ldadd) $(PMIX_LIBS)
 bizcard_SOURCES = bizcard.c
 bizcard_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)
 bizcard_LDADD = $(test_ldadd) $(PMIX_LIBS)
+
+version_SOURCES = version.c
+version_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)
+version_LDADD = $(test_ldadd) $(PMIX_LIBS)
 
 mpi_hello_SOURCES = mpi_hello.c
 mpi_hello_CPPFLAGS = $(AM_CPPFLAGS) $(OMPI_CFLAGS)

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -12,6 +12,7 @@ check_PROGRAMS = \
 	barrier \
 	bizcard \
 	version \
+	getkey \
 	mpi_hello \
 	mpi_version \
 	mpi_abort
@@ -38,6 +39,10 @@ bizcard_LDADD = $(test_ldadd) $(PMIX_LIBS)
 version_SOURCES = version.c
 version_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)
 version_LDADD = $(test_ldadd) $(PMIX_LIBS)
+
+getkey_SOURCES = getkey.c
+getkey_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
+getkey_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
 
 mpi_hello_SOURCES = mpi_hello.c
 mpi_hello_CPPFLAGS = $(AM_CPPFLAGS) $(OMPI_CFLAGS)

--- a/t/src/getkey.c
+++ b/t/src/getkey.c
@@ -1,0 +1,119 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+/* getkey.c - call PMIx_Get() on specified key,
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pmix.h>
+#include <stdio.h>
+
+#include <flux/optparse.h>
+
+#include "log.h"
+
+const char *opt_usage = "[OPTIONS] key";
+
+static struct optparse_option opts[] = {
+    { .name = "proc", .has_arg = 1, .arginfo = "RANK|*",
+      .usage = "Get key from RANK (default=self)",
+    },
+    { .name = "rank", .has_arg = 1, .arginfo = "RANK",
+      .usage = "Perform the getkey on RANK (default=0)",
+    },
+    OPTPARSE_TABLE_END,
+};
+
+static void getkey (pmix_proc_t *proc, const char *key, optparse_t *p)
+{
+    pmix_value_t *val;
+    int rc;
+
+    if ((rc = PMIx_Get (proc, key, NULL, 0, &val)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Get %s: %s", key, PMIx_Error_string (rc));
+
+    switch (val->type) {
+        case PMIX_BOOL:
+            printf ("%s\n", val->data.flag ? "true" : "false");
+            break;
+        case PMIX_UINT32:
+            printf ("%lu\n", (unsigned long)val->data.uint32);
+            break;
+        case PMIX_STRING:
+            printf ("%s\n", val->data.string);
+            break;
+        default:
+            log_msg_exit ("Error: I don't know this type yet: %d", val->type);
+    }
+
+    PMIX_VALUE_RELEASE (val);
+}
+
+int main (int argc, char **argv)
+{
+    optparse_t *p;
+    int optindex;
+    pmix_proc_t self;
+    pmix_proc_t proc = { 0 };
+    const char *key;
+    int rc;
+    int rank;
+
+    /* Parse args
+     */
+    if (!(p = optparse_create ("getkey"))
+        || optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS
+        || optparse_set (p, OPTPARSE_USAGE, opt_usage) != OPTPARSE_SUCCESS)
+        log_msg_exit ("error setting up option parsing");
+    if ((optindex = optparse_parse_args (p, argc, argv)) < 0)
+        return 1;
+    if (optindex != argc - 1) {
+        optparse_print_usage (p);
+        return 1;
+    }
+    key = argv[optindex++];
+
+    /* Initialize and set log prefix
+     */
+    char name[512];
+    if ((rc = PMIx_Init (&self, NULL, 0)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Init: %s", PMIx_Error_string (rc));
+    snprintf (name, sizeof (name), "%s.%d", self.nspace, self.rank);
+    log_init (name);
+
+    /* Parse --proc and --rank
+     */
+    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
+    proc.rank = self.rank;
+    if (optparse_hasopt (p, "proc")) {
+        const char *s = optparse_get_str (p, "proc", NULL);
+        if (!strcmp (s, "*"))
+            proc.rank = PMIX_RANK_WILDCARD;
+        else
+            proc.rank = strtoul (s, NULL, 10);
+    }
+    rank = optparse_get_int (p, "rank", 0);
+
+    /* Get key
+     */
+    if (rank == self.rank)
+        getkey (&proc, key, p);
+
+    /* Finalize
+     */
+    if ((rc = PMIx_Finalize (NULL, 0)))
+        log_msg_exit ("PMIx_Finalize: %s", PMIx_Error_string (rc));
+    optparse_destroy (p);
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/src/version.c
+++ b/t/src/version.c
@@ -1,0 +1,26 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+/* version.c - print pmix version
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pmix.h>
+#include <stdio.h>
+
+int main (int argc, char **argv)
+{
+    printf ("%s\n", PMIx_Get_version ());
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+test_description='Basic plugin tests on a single shell'
+
+PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
+
+. `dirname $0`/sharness.sh
+
+BARRIER=${FLUX_BUILD_DIR}/t/src/barrier
+BIZCARD=${FLUX_BUILD_DIR}/t/src/bizcard
+VERSION=${FLUX_BUILD_DIR}/t/src/version
+GETKEY=${FLUX_BUILD_DIR}/t/src/getkey
+
+test_under_flux 1
+
+test_expect_success 'print pmix library version' '
+	${VERSION}
+'
+
+test_expect_success 'create ompi_rc.lua script' "
+	cat >ompi_rc.lua <<-EOT
+	plugin.load (\"$PLUGINPATH/pmix.so\")
+	EOT
+"
+
+test_expect_success 'verify that plugin is loaded by ompi_rc.lua' '
+	flux mini run -o userrc=$(pwd)/ompi_rc.lua /bin/true
+'
+
+test_expect_success 'capture environment with plugin loaded' '
+	flux mini run -o userrc=$(pwd)/ompi_rc.lua printenv >env.out
+'
+
+test_expect_success 'PMIX_SERVER_URI* variables all have the same value' '
+	grep PMIX_SERVER_URI env.out | cut -d= -f2 | sort | uniq >uri.out &&
+	test $(wc -l <uri.out) -eq 1
+'
+
+test_expect_success 'server is listening on localhost' '
+	grep tcp4://127.0.0.1: uri.out
+'
+
+test_expect_success 'pmix.job.size is set correctly on rank 0' '
+	cat >size.exp <<-EOT
+	2
+	EOT
+	run_timeout 30 flux mini run -n2 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* --rank=0 pmix.job.size >size0.out &&
+	test_cmp size.exp size0.out
+'
+test_expect_success 'pmix.job.size is set correctly on rank 1' '
+	run_timeout 30 flux mini run -n2 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* --rank=1 pmix.job.size >size1.out &&
+	test_cmp size.exp size1.out
+'
+
+test_expect_success 'pmix barrier works' '
+	run_timeout 30 flux mini run -n2 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${BARRIER}
+'
+
+test_done


### PR DESCRIPTION
This adds the initial shell plugin, without the callbacks that enable inter-shell coordination, and with the absolute minimum namespace setup to allow the barrier test to work on a single shell.

I figured it would be good documentation in the history to build this up little by little, adding functionality and tests at each step.

This is based on top of #2, but if CI materializes, it should go in first.