### PR TITLE
add ci support for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+on: [ pull_request, push ]
+name: ci
+jobs:
+  check-pr:
+    name: validate commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch origin master
+    - uses: flux-framework/pr-validator@master
+
+  ci-checks:
+    runs-on: ubuntu-latest
+    env:
+      TAP_DRIVER_QUIET: 1
+      FLUX_TEST_TIMEOUT: 300
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        image: ["focal"]
+        ompi_branch: ["v5.0.x"]
+      fail-fast: false
+    name: ${{ matrix.image }} - ompi ${{ matrix.ompi_branch }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+       ref: ${{ github.event.pull_request.head.sha }}
+       fetch-depth: 0
+
+    - name: docker-run-checks
+      run: >
+        ./src/test/docker/docker-run-checks.sh
+        -j $(nproc)
+        -i ${{ matrix.image }}
+        --build-arg OMPI_BRANCH=${{ matrix.ompi_branch }}
+        --
+
+    - name: annotate errors
+      if: failure() || cancelled()
+      run: src/test/checks-annotate.sh

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,18 @@
+ull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - status-success="validate commits"
+      - status-success="focal - ompi v5.0.x"
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+      - -title~=^\[*[Ww][Ii][Pp]
+    actions:
+      merge:
+        method: merge
+        strict: smart
+        strict_method: rebase
+

--- a/src/test/backtrace-all.sh
+++ b/src/test/backtrace-all.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+#  Find all possible core files under current directory. Attempt
+#  to determine exe using file(1) and dump stack trace with gdb.
+#
+say () { printf "\033[91m%s\033[39m\n" "$@" >&2; }
+die () { say "$@"; exit 1; }
+
+find . -name '*.core' -o -name core -type f | while read -r line; do
+    d=$(dirname $line)
+    f=$(basename $line)
+    exe=$(file $line | sed "s/.*from '\([^ \t]*\).*'.*/\1/")
+    ( cd $d &&
+      exe=$(which $exe || echo $exe)
+      say "Found corefile for $exe" &&
+      test -x $exe || die "Failed to find executable at $exe" &&
+      gdb --batch --quiet -ex "thread apply all bt full" $exe $f
+    )
+done

--- a/src/test/checks-annotate.sh
+++ b/src/test/checks-annotate.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+#  Post-process testsuite logs and outputs after a failure
+#
+#  Uses GH Workflow commands for GH Actions
+#
+error() {
+    printf "::error::$@\n"
+}
+catfile() {
+    if test -f $1; then
+        printf "::group::$1\n"
+        cat $1
+        printf "::endgroup::\n"
+    fi
+}
+catfile_error() {
+    error "Found $1"
+    catfile $1
+}
+annotate_test_log() {
+    #
+    #  Look through test logfiles for various failure indicators and
+    #   emit an annotation '::error::' to the logfile if found:
+    #
+    local test=$1
+
+    #  Emit an annotation for each failed test ('not ok')
+    grep 'not ok' ${test}.log | while read line; do
+        printf "::error file=${test}.t::%s\n" "${line}"
+    done
+
+    #  Emit an annotation for TAP ERROR lines:
+    grep '^ERROR: ' ${test}.log | while read line; do
+        printf "::error file=${test}.t::%s\n" "${line}"
+    done
+
+    #  Emit an annotation for chain-lint errors:
+    grep '^error: bug in the test script' ${test}.log | while read line; do
+        printf "::error file=${test}.t::%s\n" "${line}"
+    done
+
+    #  Emit an annotation for anything that looks like an ASan error:
+    sed -n 's/==[0-9][0-9]*==ERROR: //p' ${test}.log | while read line; do
+        printf "::error file=${test}.t::%s\n" "${line}"
+    done
+}
+
+#
+#  Check all testsuite *.trs files and check for results that
+#   were not 'SKIP' or 'PASS':
+#
+logfile=/tmp/check-errors.$$
+cat /dev/null >$logfile
+
+errors=0
+total=0
+for trs in $(find . -name *.trs); do
+    : $((total++))
+    result=$(sed -n 's/^.*global-test-result: *//p' ${trs})
+    if test "$result" != "PASS" -a "$result" != "SKIP"; then
+        testbase=${trs//.trs}
+        annotate_test_log $testbase >> $logfile
+        catfile ${testbase}.output >> $logfile
+        catfile ${testbase}.log >> $logfile
+        : $((errors++))
+    fi
+done
+if test $errors -gt 0; then
+    printf "::warning::"
+fi
+printf "Found ${errors} errors from ${total} tests in testsuite\n"
+cat $logfile
+rm $logfile
+
+#
+#  Find and emit all *.asan.* files from test:
+#
+export -f catfile_error
+export -f catfile
+export -f error
+find . -name *.asan.* | xargs -i bash -c 'catfile_error {}'
+
+
+#
+#  Check for any expected tests that were not run:
+#
+ls -1 t/*.t | sort >/tmp/expected
+ls -1 t/*.trs | sed 's/rs$//' | sort >/tmp/actual
+comm -23 /tmp/expected /tmp/actual > missing
+if test -s missing; then
+    error "Detected $(wc -l missing) missing tests:"
+    for f in $(cat missing); do
+        printf "$f\n"
+        file=${f//.t}
+        test -f ${file}.log && catfile ${file}.log
+        test -f ${file}.output && catfile ${file}.output
+    done
+else
+    printf "No missing test runs detected\n"
+fi
+

--- a/src/test/checks-lib.sh
+++ b/src/test/checks-lib.sh
@@ -1,0 +1,35 @@
+#
+# Helper functions for GitHub actions, See:
+#
+# https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+#
+#
+# Only emit group/endgroup when running under CI, see:
+#
+# https://docs.github.com/en/actions/reference/environment-variables
+#
+#
+if test "$CI" = "true"; then
+  checks_group_start() {
+    printf "::group::%s\n" "$1"
+  }
+  checks_group_end() {
+    printf "::endgroup::\n"
+  }
+else
+  checks_group_start() { echo "$@"; }
+  checks_group_end()   { echo "$@"; }
+fi
+
+#
+#  Usage: checks_group DESC COMMANDS...
+#
+checks_group() {
+    local DESC="$1"
+    shift 1
+    checks_group_start "$DESC"
+    eval "$@"
+    rc=$?
+    checks_group_end
+    return $rc
+}

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+#
+#  Test runner script meant to be executed inside of a docker container
+#
+#  Usage: checks_run.sh [OPTIONS...]
+#
+#  Where OPTIONS are passed directly to ./configure
+#
+#  The script is otherwise influenced by the following environment variables:
+#
+#  JOBS=N        Argument for make's -j option, default=2
+#  PROJECT       Flux project, e.g. flux-core
+#  COVERAGE      Run with --enable-code-coverage, `make check-code-coverage`
+#  TEST_INSTALL  Run `make check` against installed flux-core
+#  CPPCHECK      Run cppcheck if set to "t"
+#  DISTCHECK     Run `make distcheck` if set
+#  RECHECK       Run `make recheck` if `make check` fails the first time
+#  UNIT_TEST_ONLY Only run `make check` under ./src
+#  PRELOAD       Set as LD_PRELOAD for make and tests
+#  POISON        Install poison libflux and flux(1) in image
+#  INCEPTION     Run tests under a flux instance
+#  chain_lint    Run sharness with --chain-lint if chain_lint=t
+#
+#  And, obviously, some crucial variables that configure itself cares about:
+#
+#  CC, CXX, LDFLAGS, CFLAGS, etc.
+#
+
+# if make is old, and scl is here, and devtoolset is available and not turned
+# on, re-exec ourself with it active to get a newer make
+if make --version | grep 'GNU Make 4' 2>&1 > /dev/null ; then
+  MAKE="make --output-sync=target --no-print-directory"
+else
+  MAKE="make" #use this if all else fails
+  if test "X$X_SCLS" = "X" ; then
+    if scl -l | grep devtoolset-7 2>&1 >/dev/null ; then
+      echo  bash "$0" "$@" | scl enable devtoolset-7 -
+      exit
+    fi
+  fi
+fi
+
+# source check_group and check_time functions:
+. src/test/checks-lib.sh
+
+ARGS="$@"
+JOBS=${JOBS:-2}
+MAKECMDS="${MAKE} -j ${JOBS}"
+CHECKCMDS="${MAKE} -j ${JOBS} ${DISTCHECK:+dist}check"
+
+# Add non-standard path for libfaketime to LD_LIBRARY_PATH:
+export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/faketime"
+
+# Force git to update the shallow clone and include tags so git-describe works
+checks_group "git fetch tags" "git fetch --unshallow --tags" \
+ git fetch --unshallow --tags || true
+
+checks_group_start "build setup"
+ulimit -c unlimited
+
+# Manually update ccache symlinks (XXX: Is this really necessary?)
+test -x /usr/sbin/update-ccache-symlinks && \
+    sudo /usr/sbin/update-ccache-symlinks
+export PATH=/usr/lib/ccache:$PATH
+
+# Ensure ccache dir exists
+mkdir -p $HOME/.ccache
+
+# clang+ccache requries second cpp pass:
+if echo "$CC" | grep -q "clang"; then
+    CCACHE_CPP=1
+fi
+
+if test "$PROJECT" = "flux-core"; then
+  # Ensure ci builds libev such that libfaketime will work:
+  # (force libev to *not* use syscall interface for clock_gettime())
+  export CPPFLAGS="$CPPFLAGS -DEV_USE_CLOCK_SYSCALL=0 -DEV_USE_MONOTONIC=1"
+
+  # Ensure we always use internal <flux/core.h> by placing a dummy file
+  #  in the same path as ZMQ_FLAGS:
+  sudo sh -c "mkdir -p /usr/include/flux \
+    && echo '#error Non-build-tree flux/core.h!' > /usr/include/flux/core.h"
+fi
+
+# Enable coverage for $CC-coverage build
+# We can't use distcheck here, it doesn't play well with coverage testing:
+if test "$COVERAGE" = "t"; then
+	# usercustomize.py must go under USER_SITE, so determine that path:
+	USER_SITE=$(python3 -c 'import site; print(site.USER_SITE)')
+	mkdir -p ${USER_SITE}
+
+	# Setup environment for Python coverage
+	# This file will be loaded by all python scripts run by the
+	# current user, but only activate coverage if COVERAGE_PROCESS_START
+	# is set in the environment.
+	#
+	cat <<-EOF >${USER_SITE}/usercustomize.py
+	try:
+	    import coverage
+	    coverage.process_startup()
+	except ImportError:
+	    pass
+	EOF
+
+	# Add Python coverage config:
+	cat <<-EOF >coverage.rc
+	[run]
+	data_file = $(pwd)/.coverage
+	include = $(pwd)/src/*
+	parallel = True
+	relative_files = True
+	omit = src/bindings/python/flux/utils/*
+	[report]
+	omit = src/bindings/python/flux/utils/*
+	EOF
+
+	rm -f .coverage .coverage*
+
+	ARGS="$ARGS --enable-code-coverage"
+	CHECKCMDS="\
+	ENABLE_USER_SITE=1 \
+	COVERAGE_PROCESS_START=$(pwd)/coverage.rc \
+	${MAKE} -j $JOBS check-code-coverage && \
+	lcov -l flux*-coverage.info && \
+	coverage combine .coverage* && \
+	coverage html && coverage xml &&
+	chmod 444 coverage.xml &&
+	coverage report"
+
+# Use make install for T_INSTALL:
+elif test "$TEST_INSTALL" = "t"; then
+    ARGS="$ARGS --prefix=/usr --sysconfdir=/etc"
+    CHECKCMDS="sudo make install && \
+              FLUX_TEST_INSTALLED_PATH=/usr/bin ${MAKE} -j $JOBS check"
+
+# Run checks as Flux jobs:
+elif test "$INCEPTION" = "t"; then
+	CHECKCMDS="make -j ${JOBS} check-prep && \
+	           cd t && ../src/cmd/flux start -s1 ./test-inception.sh && \
+	           cd .."
+fi
+
+if test -n "$PRELOAD" ; then
+  CHECKCMDS="/usr/bin/env 'LD_PRELOAD=$PRELOAD' ${CHECKCMDS}"
+fi
+
+if test -n "$UNIT_TEST_ONLY"; then
+  CHECKCMDS="(cd src && $CHECKCMDS)"
+fi
+
+# CI has limited resources, even though number of processors might
+#  might appear to be large. Limit session size for testing to 5 to avoid
+#  spurious timeouts.
+export FLUX_TEST_SIZE_MAX=5
+
+# Invoke MPI tests
+# CentOS 7: mpich only available via environment-module:
+if test -f /usr/share/Modules/init/bash; then
+    . /usr/share/Modules/init/bash && module load mpi
+fi
+export FLUX_TEST_MPI=t
+
+# Generate logfiles from sharness tests for extra information:
+export FLUX_TESTS_LOGFILE=t
+export DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
+
+# Force enable valgrind test
+export FLUX_ENABLE_VALGRIND_TEST=t
+
+if test "$CPPCHECK" = "t"; then
+    sh -x src/test/cppcheck.sh
+fi
+
+echo "Starting MUNGE"
+sudo /sbin/runuser -u munge /usr/sbin/munged
+
+checks_group_end # Setup
+
+checks_group "autogen.sh" ./autogen.sh
+
+WORKDIR=$(pwd)
+if test -n "$BUILD_DIR" ; then
+  mkdir -p "$BUILD_DIR"
+  cd "$BUILD_DIR"
+fi
+
+checks_group "configure ${ARGS}"  ${WORKDIR}/configure ${ARGS} \
+	|| (printf "::error::configure failed\n"; cat config.log; exit 1)
+checks_group "make clean..." make clean
+
+if test "$POISON" = "t" -a "$PROJECT" = "flux-core"; then
+  checks_group "Installing poison libflux..." \
+    bash src/test/docker/poison-libflux.sh
+fi
+
+if test "$DISTCHECK" != "t"; then
+  checks_group "${MAKECMDS}" "${MAKECMDS}" \
+	|| (printf "::error::${MAKECMDS} failed\n"; exit 1)
+fi
+checks_group "${CHECKCMDS}" "${CHECKCMDS}"
+RC=$?
+
+if test "$RECHECK" = "t" -a $RC -ne 0; then
+  #
+  # `make recheck` is not recursive, only perform it if at least some tests
+  #   under ./t were run (and presumably failed)
+  #
+  if test -s t/t0000-sharness.trs; then
+    cd t
+    printf "::warning::make check failed, trying recheck in ./t\n"
+    checks_group "make recheck" ${MAKE} -j ${JOBS} recheck
+    RC=$?
+    cd
+   else
+      printf "::warning::recheck requested but no tests in ./t were run\n"
+   fi
+fi
+
+exit $RC

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+#
+#  Build flux "checks" docker image and run tests, exporting
+#   important environment variables to the docker environment.
+#
+#  Arguments here are passed directly to ./configure
+#
+#
+# option Defaults:
+PROJECT=flux-pmix
+BASE_DOCKER_REPO=fluxrm/flux-core
+
+WORKDIR=/usr/src
+IMAGE=focal
+JOBS=2
+MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
+
+if test "$PROJECT" = "flux-core"; then
+  FLUX_SECURITY_VERSION=0.5.0
+  POISON=t
+fi
+
+#
+declare -r prog=${0##*/}
+die() { echo -e "$prog: $@"; exit 1; }
+
+#
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,inception,platform:,workdir:"
+declare -r short_opts="hqIdi:S:j:t:D:Prup:"
+declare -r usage="
+Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
+Build docker image for CI builds, then run tests inside the new\n\
+container as the current user and group.\n\
+\n\
+Uses the current git repo for the build.\n\
+\n\
+Options:\n\
+ -h, --help                    Display this message\n\
+     --no-cache                Disable docker caching\n\
+     --no-home                 Skip mounting the host home directory\n\
+     --install-only            Skip make check, only make install\n\
+     --inception               Run tests as flux jobs\n\
+ -q, --quiet                   Add --quiet to docker-build\n\
+ -t, --tag=TAG                 If checks succeed, tag image as NAME\n\
+ -i, --image=NAME              Use base docker image NAME (default=$IMAGE)\n\
+ -p, --platform=NAME           Run on alternate platform (if supported)\n\
+ -S, --flux-security-version=N Install flux-security vers N (default=$FLUX_SECURITY_VERSION)\n
+ -j, --jobs=N                  Value for make -j (default=$JOBS)\n
+ -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
+ -r, --recheck                 Run 'make recheck' after failure\n\
+ -u, --unit-test-only          Only run unit tests\n\
+ -P, --no-poison               Do not install poison libflux and flux(1)\n\
+ -D, --build-directory=DIRNAME Name of a subdir to build in, will be made\n\
+     --workdir=PATH            Use PATH as working directory for build\n\
+ -I, --interactive             Instead of running ci build, run docker\n\
+                                image with interactive shell.\n\
+"
+
+# check if running in OSX
+if [[ "$(uname)" == "Darwin" ]]; then
+    # BSD getopt
+    GETOPTS=`/usr/bin/getopt $short_opts -- $*`
+else
+    # GNU getopt
+    GETOPTS=`/usr/bin/getopt -u -o $short_opts -l $long_opts -n $prog -- $@`
+    if [[ $? != 0 ]]; then
+        die "$usage"
+    fi
+    eval set -- "$GETOPTS"
+fi
+while true; do
+    case "$1" in
+      -h|--help)                   echo -ne "$usage";          exit 0  ;;
+      -q|--quiet)                  QUIET="--quiet";            shift   ;;
+      -i|--image)                  IMAGE="$2";                 shift 2 ;;
+      -p|--platform)               PLATFORM="--platform=$2";   shift 2 ;;
+      -S|--flux-security-version)  FLUX_SECURITY_VERSION="$2"; shift 2 ;;
+      -j|--jobs)                   JOBS="$2";                  shift 2 ;;
+      -I|--interactive)            INTERACTIVE="/bin/bash";    shift   ;;
+      -d|--distcheck)              DISTCHECK=t;                shift   ;;
+      -r|--recheck)                RECHECK=t;                  shift   ;;
+      -u|--unit-test-only)         UNIT_TEST_ONLY=t;           shift   ;;
+      -D|--build-directory)        BUILD_DIR="$2";             shift 2 ;;
+      --workdir)                   WORKDIR="$2";               shift 2 ;;
+      --no-cache)                  NO_CACHE="--no-cache";      shift   ;;
+      --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
+      --install-only)              INSTALL_ONLY=t;             shift   ;;
+      --inception)                 INCEPTION=t;                shift   ;;
+      -P|--no-poison)              POISON=0;                   shift   ;;
+      -t|--tag)                    TAG="$2";                   shift 2 ;;
+      --)                          shift; break;                       ;;
+      *)                           die "Invalid option '$1'\n$usage"   ;;
+    esac
+done
+
+TOP=$(git rev-parse --show-toplevel 2>&1) \
+    || die "not inside $PROJECT git repository!"
+which docker >/dev/null \
+    || die "unable to find a docker binary"
+if docker buildx >/dev/null 2>&1; then
+    DOCKER_BUILD="docker buildx build --load"
+else
+    DOCKER_BUILD="docker build"
+fi
+
+# distcheck incompatible with some configure args
+if test "$DISTCHECK" = "t"; then
+    test "$RECHECK" = "t" && die "--recheck not allowed with --distcheck"
+    for arg in "$@"; do
+        case $arg in
+          --sysconfdir=*|systemdsystemunitdir=*)
+            die "distcheck incompatible with configure arg $arg"
+        esac
+    done
+fi
+
+CONFIGURE_ARGS="$@"
+
+. ${TOP}/src/test/checks-lib.sh
+
+#  NOTE: BASE_IMAGE, IMAGESRC, FLUX_SECURITY_VERSION are ignored
+#   unless in flux-core repo
+#
+BUILD_IMAGE=checks-builder:${IMAGE}
+if test "$PROJECT" = "flux-core"; then
+    DOCKERFILE=$TOP/src/test/docker/checks
+else
+    DOCKERFILE=$TOP/src/test/docker/$IMAGE
+fi
+
+checks_group "Building image $IMAGE for user $USER $(id -u) group=$(id -g)" \
+  ${DOCKER_BUILD} \
+    ${PLATFORM} \
+    ${NO_CACHE} \
+    ${QUIET} \
+    --build-arg BASE_IMAGE=$IMAGE \
+    --build-arg IMAGESRC="$BASE_DOCKER_REPO:$IMAGE" \
+    --build-arg USER=$USER \
+    --build-arg UID=$(id -u) \
+    --build-arg GID=$(id -g) \
+    --build-arg FLUX_SECURITY_VERSION=$FLUX_SECURITY_VERSION \
+    -t ${BUILD_IMAGE} \
+    ${DOCKERFILE} \
+    || die "docker build failed"
+
+if [[ -n "$MOUNT_HOME_ARGS" ]]; then
+    echo "mounting $HOME as /home/$USER"
+fi
+echo "mounting $TOP as $WORKDIR"
+
+export PROJECT
+export POISON
+export INCEPTION
+export JOBS
+export DISTCHECK
+export RECHECK
+export UNIT_TEST_ONLY
+export BUILD_DIR
+export chain_lint
+
+if [[ "$INSTALL_ONLY" == "t" ]]; then
+    docker run --rm \
+        --workdir=$WORKDIR \
+        --volume=$TOP:$WORKDIR \
+        ${PLATFORM} \
+        ${BUILD_IMAGE} \
+        sh -c "./autogen.sh &&
+               ./configure --prefix=/usr --sysconfdir=/etc \
+                --with-systemdsystemunitdir=/etc/systemd/system \
+                --localstatedir=/var \
+                --with-flux-security \
+                --enable-caliper &&
+               make clean &&
+               make -j${JOBS}" \
+    || (docker rm tmp.$$; die "docker run of 'make install' failed")
+else
+    docker run --rm \
+        --workdir=$WORKDIR \
+        --volume=$TOP:$WORKDIR \
+        ${PLATFORM} \
+        $MOUNT_HOME_ARGS \
+        -e CC \
+        -e CXX \
+        -e LDFLAGS \
+        -e CFLAGS \
+        -e CPPFLAGS \
+        -e GCOV \
+        -e CCACHE_CPP2 \
+        -e CCACHE_READONLY \
+        -e COVERAGE \
+        -e TEST_INSTALL \
+        -e CPPCHECK \
+        -e DISTCHECK \
+        -e RECHECK \
+        -e UNIT_TEST_ONLY \
+        -e chain_lint \
+        -e JOBS \
+        -e USER \
+	-e PROJECT \
+        -e CI \
+        -e TAP_DRIVER_QUIET \
+        -e TEST_CHECK_PREREQS \
+        -e FLUX_TEST_TIMEOUT \
+        -e FLUX_TEST_SIZE_MAX \
+        -e PYTHON_VERSION \
+        -e PRELOAD \
+        -e POISON \
+        -e INCEPTION \
+        -e ASAN_OPTIONS \
+        -e BUILD_DIR \
+        -e S3_ACCESS_KEY_ID \
+        -e S3_SECRET_ACCESS_KEY \
+        -e S3_HOSTNAME \
+        -e S3_BUCKET \
+        --cap-add SYS_PTRACE \
+        --tty \
+        ${INTERACTIVE:+--interactive} \
+        --network=host \
+        ${BUILD_IMAGE} \
+        ${INTERACTIVE:-./src/test/checks_run.sh ${CONFIGURE_ARGS}} \
+    || die "docker run failed"
+fi
+
+if test -n "$TAG"; then
+    # Re-run 'make install' in fresh image, otherwise we get all
+    # the context from the build above
+    docker run --name=tmp.$$ \
+        --workdir=${WORKDIR}/${BUILD_DIR} \
+        --volume=$TOP:${WORKDIR} \
+        --user="root" \
+        ${PLATFORM} \
+	${BUILD_IMAGE} \
+	sh -c "make install && \
+               userdel $USER" \
+	|| (docker rm tmp.$$; die "docker run of 'make install' failed")
+    docker commit \
+	--change 'ENTRYPOINT [ "/usr/local/sbin/entrypoint.sh" ]' \
+	--change 'CMD [ "/usr/bin/flux",  "start", "/bin/bash" ]' \
+	--change 'USER fluxuser' \
+	--change 'WORKDIR /home/fluxuser' \
+	tmp.$$ $TAG \
+	|| die "docker commit failed"
+    docker rm tmp.$$
+    echo "Tagged image $TAG"
+fi

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -25,7 +25,7 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,inception,platform:,workdir:"
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,inception,platform:,workdir:,build-arg:"
 declare -r short_opts="hqIdi:S:j:t:D:Prup:"
 declare -r usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
@@ -40,6 +40,7 @@ Options:\n\
      --no-home                 Skip mounting the host home directory\n\
      --install-only            Skip make check, only make install\n\
      --inception               Run tests as flux jobs\n\
+     --build-arg ARG=VAL       Add extra --buil-args to to docker build\n\
  -q, --quiet                   Add --quiet to docker-build\n\
  -t, --tag=TAG                 If checks succeed, tag image as NAME\n\
  -i, --image=NAME              Use base docker image NAME (default=$IMAGE)\n\
@@ -88,6 +89,8 @@ while true; do
       --inception)                 INCEPTION=t;                shift   ;;
       -P|--no-poison)              POISON=0;                   shift   ;;
       -t|--tag)                    TAG="$2";                   shift 2 ;;
+      --build-arg)                 BUILD_ARG="$BUILD_ARG --build-arg $2"
+                                                               shift 2 ;;
       --)                          shift; break;                       ;;
       *)                           die "Invalid option '$1'\n$usage"   ;;
     esac
@@ -139,6 +142,7 @@ checks_group "Building image $IMAGE for user $USER $(id -u) group=$(id -g)" \
     --build-arg UID=$(id -u) \
     --build-arg GID=$(id -g) \
     --build-arg FLUX_SECURITY_VERSION=$FLUX_SECURITY_VERSION \
+    ${BUILD_ARG} \
     -t ${BUILD_IMAGE} \
     ${DOCKERFILE} \
     || die "docker build failed"

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -1,0 +1,41 @@
+FROM fluxrm/flux-core:focal
+
+ARG USER=fluxuser
+ARG UID=1000
+ARG OMPI_BRANCH=v5.0.x
+
+RUN \
+ if test "$USER" != "fluxuser"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo adduser $USER sudo ; \
+ fi
+
+# ompi can't coexist with mpich
+RUN sudo apt remove -yy mpich libmpich-dev libmpich12
+
+# install ompi prereqs
+RUN sudo apt-get update \
+ && sudo apt-get -qq install -y --no-install-recommends \
+    libevent-dev \
+    flex \
+    openssh-client \
+ && sudo rm -rf /var/lib/apt/lists/*
+
+# build/install ompi
+RUN cd /tmp \
+ && git clone -b ${OMPI_BRANCH} \
+       --recursive --depth=1 https://github.com/open-mpi/ompi \
+ && cd ompi \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --disable-man-pages --enable-debug --enable-mem-debug \
+ && make -j $(nproc) \
+ && sudo make install \
+ && cd .. \
+ && rm -rf ompi
+
+USER $USER
+WORKDIR /home/$USER
+

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -13,7 +13,8 @@ RUN \
  fi
 
 # ompi can't coexist with mpich
-RUN sudo apt remove -yy mpich libmpich-dev libmpich12
+RUN sudo apt remove -yy mpich libmpich-dev libmpich12 \
+ && sudo apt clean
 
 # install ompi prereqs
 RUN sudo apt-get update \
@@ -21,13 +22,15 @@ RUN sudo apt-get update \
     libevent-dev \
     flex \
     openssh-client \
+ && sudo apt clean \
  && sudo rm -rf /var/lib/apt/lists/*
 
 # build/install ompi
 RUN cd /tmp \
  && git clone -b ${OMPI_BRANCH} \
-       --recursive --depth=1 https://github.com/open-mpi/ompi \
+      --recursive --depth=1 https://github.com/open-mpi/ompi \
  && cd ompi \
+ && git branch \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
       --disable-man-pages --enable-debug --enable-mem-debug \


### PR DESCRIPTION
This PR adds a Dockerfile for `focal`, `docker-run-checks.sh` from flux-core, and a github workflow to enable CI on all PRs in this repo. It also adds a simple `.mergify.yml` so that mergify can be enabled.

Currently, the CI wil run against ompi v5.0.x branch in Ubuntu focal only, though the workflow is set up to easily allow different branches of OpenMPI to be built and installed.

This is built on top of the current `main`, so no checks are run. @garlick, if you want, instead of merging this PR you could just pull the commits into your existing testsuite PR so that `make check` actually does something. Otherwise, this PR could be merged and the testsuite PR rebased on top.