### PR TITLE
plugin: set up the basic nspace

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,3 +5,5 @@ EXTRA_DIST = \
 	README.md \
 	NOTICE.LLNS \
 	config/tap-driver.sh
+
+ACLOCAL_AMFLAGS = -I config

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,7 @@
-SUBDIRS = src/shell/plugins t
+SUBDIRS = \
+	src/common/libtap \
+	src/shell/plugins \
+	t
 
 EXTRA_DIST = \
 	NEWS.md \

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,7 @@ AC_SUBST(fluxplugin_ldflags)
 ##
 AC_CONFIG_FILES( \
   Makefile \
+  src/common/libtap/Makefile \
   src/shell/plugins/Makefile \
   t/Makefile \
   t/sharness.d/00-setup.sh \

--- a/src/common/libtap/Makefile.am
+++ b/src/common/libtap/Makefile.am
@@ -1,0 +1,12 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS =
+
+check_LTLIBRARIES = libtap.la
+
+libtap_la_SOURCES = tap.c tap.h

--- a/src/common/libtap/tap.c
+++ b/src/common/libtap/tap.c
@@ -1,0 +1,354 @@
+/*
+libtap - Write tests in C
+Copyright 2012 Jake Gelbman <gelbman@gmail.com>
+This file is licensed under the LGPL
+*/
+
+#define _DEFAULT_SOURCE 1
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include "tap.h"
+
+static int expected_tests = NO_PLAN;
+static int failed_tests;
+static int current_test;
+static char *todo_mesg;
+
+static char *
+vstrdupf (const char *fmt, va_list args) {
+    char *str;
+    int size;
+    va_list args2;
+    va_copy(args2, args);
+    if (!fmt)
+        fmt = "";
+    size = vsnprintf(NULL, 0, fmt, args2) + 2;
+    str = malloc(size);
+    if (!str) {
+        perror("malloc error");
+        exit(1);
+    }
+    vsprintf(str, fmt, args);
+    va_end(args2);
+    return str;
+}
+
+void
+tap_plan (int tests, const char *fmt, ...) {
+    expected_tests = tests;
+    if (tests == SKIP_ALL) {
+        char *why;
+        va_list args;
+        va_start(args, fmt);
+        why = vstrdupf(fmt, args);
+        va_end(args);
+        printf("1..0 ");
+        diag("SKIP %s\n", why);
+        exit(0);
+    }
+    if (tests != NO_PLAN) {
+        printf("1..%d\n", tests);
+    }
+}
+
+int
+vok_at_loc (const char *file, int line, int test, const char *fmt,
+            va_list args)
+{
+    char *name = vstrdupf(fmt, args);
+    if (!test) {
+        printf("not ");
+    }
+    printf("ok %d", ++current_test);
+    if (*name)
+        printf(" - %s", name);
+    if (todo_mesg) {
+        printf(" # TODO");
+        if (*todo_mesg)
+            printf(" %s", todo_mesg);
+    }
+    printf("\n");
+    if (!test) {
+        printf("#   Failed ");
+        if (todo_mesg)
+            printf("(TODO) ");
+        printf("test ");
+        if (*name)
+            printf("'%s'\n#   ", name);
+        printf("at %s line %d.\n", file, line);
+        if (!todo_mesg)
+            failed_tests++;
+    }
+    free(name);
+    return test;
+}
+
+int
+ok_at_loc (const char *file, int line, int test, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vok_at_loc(file, line, test, fmt, args);
+    va_end(args);
+    return test;
+}
+
+static int
+mystrcmp (const char *a, const char *b) {
+    return a == b ? 0 : !a ? -1 : !b ? 1 : strcmp(a, b);
+}
+
+#define eq(a, b) (!mystrcmp(a, b))
+#define ne(a, b) (mystrcmp(a, b))
+
+int
+is_at_loc (const char *file, int line, const char *got, const char *expected,
+           const char *fmt, ...)
+{
+    int test = eq(got, expected);
+    va_list args;
+    va_start(args, fmt);
+    vok_at_loc(file, line, test, fmt, args);
+    va_end(args);
+    if (!test) {
+        diag("         got: '%s'", got);
+        diag("    expected: '%s'", expected);
+    }
+    return test;
+}
+
+int
+isnt_at_loc (const char *file, int line, const char *got, const char *expected,
+             const char *fmt, ...)
+{
+    int test = ne(got, expected);
+    va_list args;
+    va_start(args, fmt);
+    vok_at_loc(file, line, test, fmt, args);
+    va_end(args);
+    if (!test) {
+        diag("         got: '%s'", got);
+        diag("    expected: anything else");
+    }
+    return test;
+}
+
+int
+cmp_ok_at_loc (const char *file, int line, int a, const char *op, int b,
+               const char *fmt, ...)
+{
+    int test = eq(op, "||") ? a || b
+             : eq(op, "&&") ? a && b
+             : eq(op, "|")  ? a |  b
+             : eq(op, "^")  ? a ^  b
+             : eq(op, "&")  ? a &  b
+             : eq(op, "==") ? a == b
+             : eq(op, "!=") ? a != b
+             : eq(op, "<")  ? a <  b
+             : eq(op, ">")  ? a >  b
+             : eq(op, "<=") ? a <= b
+             : eq(op, ">=") ? a >= b
+             : eq(op, "<<") ? a << b
+             : eq(op, ">>") ? a >> b
+             : eq(op, "+")  ? a +  b
+             : eq(op, "-")  ? a -  b
+             : eq(op, "*")  ? a *  b
+             : eq(op, "/")  ? a /  b
+             : eq(op, "%")  ? a %  b
+             : diag("unrecognized operator '%s'", op);
+    va_list args;
+    va_start(args, fmt);
+    vok_at_loc(file, line, test, fmt, args);
+    va_end(args);
+    if (!test) {
+        diag("    %d", a);
+        diag("        %s", op);
+        diag("    %d", b);
+    }
+    return test;
+}
+
+static int
+find_mem_diff (const char *a, const char *b, size_t n, size_t *offset) {
+    size_t i;
+    if (a == b)
+        return 0;
+    if (!a || !b)
+        return 2;
+    for (i = 0; i < n; i++) {
+        if (a[i] != b[i]) {
+            *offset = i;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int
+cmp_mem_at_loc (const char *file, int line, const void *got,
+                const void *expected, size_t n, const char *fmt, ...)
+{
+    size_t offset;
+    int diff = find_mem_diff(got, expected, n, &offset);
+    va_list args;
+    va_start(args, fmt);
+    vok_at_loc(file, line, !diff, fmt, args);
+    va_end(args);
+    if (diff == 1) {
+        diag("    Difference starts at offset %d", offset);
+        diag("         got: 0x%02x", ((unsigned char *)got)[offset]);
+        diag("    expected: 0x%02x", ((unsigned char *)expected)[offset]);
+    }
+    else if (diff == 2) {
+        diag("         got: %s", got ? "not NULL" : "NULL");
+        diag("    expected: %s", expected ? "not NULL" : "NULL");
+    }
+    return !diff;
+}
+
+int
+diag (const char *fmt, ...) {
+    va_list args;
+    char *mesg, *line;
+    int i;
+    va_start(args, fmt);
+    if (!fmt)
+        return 0;
+    mesg = vstrdupf(fmt, args);
+    line = mesg;
+    for (i = 0; *line; i++) {
+        char c = mesg[i];
+        if (!c || c == '\n') {
+            mesg[i] = '\0';
+            printf("# %s\n", line);
+            if (!c)
+                break;
+            mesg[i] = c;
+            line = mesg + i + 1;
+        }
+    }
+    free(mesg);
+    va_end(args);
+    return 0;
+}
+
+int
+exit_status () {
+    int retval = 0;
+    if (expected_tests == NO_PLAN) {
+        printf("1..%d\n", current_test);
+    }
+    else if (current_test != expected_tests) {
+        diag("Looks like you planned %d test%s but ran %d.",
+            expected_tests, expected_tests > 1 ? "s" : "", current_test);
+        retval = 2;
+    }
+    if (failed_tests) {
+        diag("Looks like you failed %d test%s of %d run.",
+            failed_tests, failed_tests > 1 ? "s" : "", current_test);
+        retval = 1;
+    }
+    return retval;
+}
+
+int
+bail_out (int ignore, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    printf("Bail out!  ");
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+    exit(255);
+    return 0;
+}
+
+void
+tap_skip (int n, const char *fmt, ...) {
+    char *why;
+    va_list args;
+    va_start(args, fmt);
+    why = vstrdupf(fmt, args);
+    va_end(args);
+    while (n --> 0) {
+        printf("ok %d ", ++current_test);
+        diag("skip %s\n", why);
+    }
+    free(why);
+}
+
+void
+tap_todo (int ignore, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    todo_mesg = vstrdupf(fmt, args);
+    va_end(args);
+}
+
+void
+tap_end_todo () {
+    free(todo_mesg);
+    todo_mesg = NULL;
+}
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <regex.h>
+
+#if defined __APPLE__ || defined BSD
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+/* Create a shared memory int to keep track of whether a piece of code executed
+dies. to be used in the dies_ok and lives_ok macros.  */
+int
+tap_test_died (int status) {
+    static int *test_died = NULL;
+    int prev;
+    if (!test_died) {
+        test_died = mmap(0, sizeof (int), PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *test_died = 0;
+    }
+    prev = *test_died;
+    *test_died = status;
+    return prev;
+}
+
+int
+like_at_loc (int for_match, const char *file, int line, const char *got,
+             const char *expected, const char *fmt, ...)
+{
+    int test;
+    regex_t re;
+    va_list args;
+    int err = regcomp(&re, expected, REG_EXTENDED);
+    if (err) {
+        char errbuf[256];
+        regerror(err, &re, errbuf, sizeof errbuf);
+        fprintf(stderr, "Unable to compile regex '%s': %s at %s line %d\n",
+                        expected, errbuf, file, line);
+        exit(255);
+    }
+    err = regexec(&re, got, 0, NULL, 0);
+    regfree(&re);
+    test = for_match ? !err : err;
+    va_start(args, fmt);
+    vok_at_loc(file, line, test, fmt, args);
+    va_end(args);
+    if (!test) {
+        if (for_match) {
+            diag("                   '%s'", got);
+            diag("    doesn't match: '%s'", expected);
+        }
+        else {
+            diag("                   '%s'", got);
+            diag("          matches: '%s'", expected);
+        }
+    }
+    return test;
+}
+#endif

--- a/src/common/libtap/tap.h
+++ b/src/common/libtap/tap.h
@@ -1,0 +1,115 @@
+/*
+libtap - Write tests in C
+Copyright 2012 Jake Gelbman <gelbman@gmail.com>
+This file is licensed under the LGPL
+*/
+
+#ifndef __TAP_H__
+#define __TAP_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef va_copy
+#ifdef __va_copy
+#define va_copy __va_copy
+#else
+#define va_copy(d, s) ((d) = (s))
+#endif
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+int     vok_at_loc      (const char *file, int line, int test, const char *fmt,
+                         va_list args);
+int     ok_at_loc       (const char *file, int line, int test, const char *fmt,
+                         ...);
+int     is_at_loc       (const char *file, int line, const char *got,
+                         const char *expected, const char *fmt, ...);
+int     isnt_at_loc     (const char *file, int line, const char *got,
+                         const char *expected, const char *fmt, ...);
+int     cmp_ok_at_loc   (const char *file, int line, int a, const char *op,
+                         int b, const char *fmt, ...);
+int     cmp_mem_at_loc  (const char *file, int line, const void *got,
+                         const void *expected, size_t n, const char *fmt, ...);
+int     bail_out        (int ignore, const char *fmt, ...);
+void    tap_plan        (int tests, const char *fmt, ...);
+int     diag            (const char *fmt, ...);
+int     exit_status     (void);
+void    tap_skip        (int n, const char *fmt, ...);
+void    tap_todo        (int ignore, const char *fmt, ...);
+void    tap_end_todo    (void);
+
+#define NO_PLAN          -1
+#define SKIP_ALL         -2
+#define ok(...)          ok_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
+#define is(...)          is_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
+#define isnt(...)        isnt_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
+#define cmp_ok(...)      cmp_ok_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
+#define cmp_mem(...)     cmp_mem_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL);
+#define plan(...)        tap_plan(__VA_ARGS__, NULL)
+#define done_testing()   return exit_status()
+#define BAIL_OUT(...)    bail_out(0, "" __VA_ARGS__, NULL)
+#define pass(...)        ok(1, "" __VA_ARGS__)
+#define fail(...)        ok(0, "" __VA_ARGS__)
+
+#define skip(test, ...)  do {if (test) {tap_skip(__VA_ARGS__, NULL); break;}
+#define end_skip         } while (0)
+
+#define todo(...)        tap_todo(0, "" __VA_ARGS__, NULL)
+#define end_todo         tap_end_todo()
+
+#define dies_ok(...)     dies_ok_common(1, __VA_ARGS__)
+#define lives_ok(...)    dies_ok_common(0, __VA_ARGS__)
+
+#ifdef _WIN32
+#define like(...)        tap_skip(1, "like is not implemented on Windows")
+#define unlike           tap_skip(1, "unlike is not implemented on Windows")
+#define dies_ok_common(...) \
+                         tap_skip(1, "Death detection is not supported on Windows")
+#else
+#define like(...)        like_at_loc(1, __FILE__, __LINE__, __VA_ARGS__, NULL)
+#define unlike(...)      like_at_loc(0, __FILE__, __LINE__, __VA_ARGS__, NULL)
+int     like_at_loc     (int for_match, const char *file, int line,
+                         const char *got, const char *expected,
+                         const char *fmt, ...);
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+int tap_test_died (int status);
+#define dies_ok_common(for_death, code, ...)                \
+    do {                                                    \
+        int cpid;                                           \
+        int it_died;                                        \
+        tap_test_died(1);                                   \
+        cpid = fork();                                      \
+        switch (cpid) {                                     \
+        case -1:                                            \
+            perror("fork error");                           \
+            exit(1);                                        \
+        case 0:                                             \
+            close(1);                                       \
+            close(2);                                       \
+            code                                            \
+            tap_test_died(0);                               \
+            exit(0);                                        \
+        }                                                   \
+        if (waitpid(cpid, NULL, 0) < 0) {                   \
+            perror("waitpid error");                        \
+            exit(1);                                        \
+        }                                                   \
+        it_died = tap_test_died(0);                         \
+        if (!it_died)                                       \
+            {code}                                          \
+        ok(for_death ? it_died : !it_died, "" __VA_ARGS__); \
+    } while (0)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -12,7 +12,9 @@ shell_plugin_LTLIBRARIES = \
 pmix_la_SOURCES = \
 	main.c \
 	infovec.h \
-	infovec.c
+	infovec.c \
+	maps.h \
+	maps.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -10,7 +10,9 @@ shell_plugin_LTLIBRARIES = \
 	pmix.la
 
 pmix_la_SOURCES = \
-	main.c
+	main.c \
+	infovec.h \
+	infovec.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \
@@ -28,3 +30,30 @@ pmix_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(fluxplugin_ldflags) \
 	-module
+
+TESTS = \
+	test_infovec.t
+
+test_ldadd = \
+	$(top_builddir)/src/common/libtap/libtap.la
+
+test_ldflags = \
+        -no-install
+
+test_cppflags = \
+        -I$(top_srcdir)/src/common/libtap \
+        $(AM_CPPFLAGS)
+
+check_PROGRAMS = $(TESTS)
+
+test_infovec_t_SOURCES = \
+        infovec.c \
+        infovec.h \
+        test/infovec.c
+test_infovec_t_CPPFLAGS = \
+        $(PMIX_CFLAGS) \
+        $(test_cppflags)
+test_infovec_t_LDADD = \
+        $(test_ldadd)
+test_infovec_t_LDFLAGS = \
+        $(test_ldflags)

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -1,0 +1,166 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* infovec.c - helper class for working with pmix_info_t arrays
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <pmix.h>
+
+#include "infovec.h"
+
+#define INFOVEC_CHUNK 8
+
+struct infovec {
+    int length;
+    int count;
+    pmix_info_t *info;
+};
+
+static pmix_info_t *alloc_slot (struct infovec *iv)
+{
+    if (iv->count == iv->length) {
+        int new_length = iv->length + INFOVEC_CHUNK;
+        size_t new_size = sizeof (iv->info[0]) * new_length;
+        pmix_info_t *new_info;
+
+        if (!(new_info = realloc (iv->info, new_size)))
+            return NULL;
+        iv->info = new_info;
+        iv->length = new_length;
+    }
+    return &iv->info[iv->count++];
+}
+
+int infovec_set_str_new (struct infovec *iv, const char *key, char *val)
+{
+    char *cpy;
+    pmix_info_t *info;
+
+    if (!iv || !key || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_STRING;
+    info->value.data.string = val;
+    return 0;
+}
+
+int infovec_set_str (struct infovec *iv, const char *key, const char *val)
+{
+    char *cpy;
+    pmix_info_t *info;
+
+    if (!iv || !key || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = strdup (val))
+        || infovec_set_str_new (iv, key, cpy) < 0) {
+        int saved_errno = errno;
+        free (cpy);
+        errno = saved_errno;
+        return -1;
+    }
+    return 0;
+}
+
+int infovec_set_u32 (struct infovec *iv, const char *key, uint32_t value)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_UINT32;
+    info->value.data.uint32 = value;
+    return 0;
+}
+
+int infovec_set_bool (struct infovec *iv, const char *key, bool value)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_BOOL;
+    info->value.data.flag = value;
+    return 0;
+}
+
+int infovec_set_rank (struct infovec *iv,
+                      const char *key,
+                      pmix_rank_t value)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_PROC_RANK;
+    info->value.data.rank = value;
+    return 0;
+}
+
+int infovec_count (struct infovec *iv)
+{
+    return iv->count;
+}
+
+pmix_info_t *infovec_info (struct infovec *iv)
+{
+    return iv->info;
+}
+
+void infovec_destroy (struct infovec *iv)
+{
+    if (iv) {
+        int saved_errno = errno;
+        for (int i = 0; i < iv->count; i++) {
+            pmix_value_t *value = &iv->info[i].value;
+            switch (value->type) {
+                case PMIX_STRING:
+                    free (value->data.string);
+                    break;
+            }
+        }
+        free (iv);
+        errno = saved_errno;
+    }
+}
+
+struct infovec *infovec_create (void)
+{
+    struct infovec *iv;
+    if (!(iv = calloc (1, sizeof (*iv))))
+        return NULL;
+    return iv;
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/infovec.h
+++ b/src/shell/plugins/infovec.h
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_INFOVEC_H
+#define _PX_INFOVEC_H
+
+#include <pmix.h>
+
+struct infovec *infovec_create (void);
+void infovec_destroy (struct infovec *iv);
+
+int infovec_set_u32 (struct infovec *iv, const char *key, uint32_t val);
+int infovec_set_str (struct infovec *iv, const char *key, const char *str);
+int infovec_set_str_new (struct infovec *iv, const char *key, char *str);
+int infovec_set_bool (struct infovec *iv, const char *key, bool val);
+int infovec_set_rank (struct infovec *iv, const char *key, pmix_rank_t val);
+
+int infovec_count (struct infovec *iv);
+pmix_info_t *infovec_info (struct infovec *iv);
+
+#endif // _PX_INFOVEC_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -93,6 +93,7 @@ static int px_init (flux_plugin_t *p,
     }
 
     if (!(iv = infovec_create ())
+        || infovec_set_str (iv, PMIX_NSDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_JOB_NUM_APPS, 1) < 0
         || infovec_set_str (iv, PMIX_TMPDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_LOCAL_SIZE, px->local_nprocs) < 0

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -100,7 +100,7 @@ static int px_init (flux_plugin_t *p,
     flux_shell_t *shell = flux_plugin_get_shell (p);
     struct px *px;
     int rc;
-    pmix_info_t info = { 0 };
+    pmix_info_t info[2] = { 0 };
     const char *s;
     struct infovec *iv;
 
@@ -132,11 +132,15 @@ static int px_init (flux_plugin_t *p,
     if (!(px->job_tmpdir = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR")))
         return -1;
 
-    strncpy (info.key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN);
-    info.value.type = PMIX_STRING;
-    info.value.data.string = (char *)px->job_tmpdir;
+    strncpy (info[0].key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN);
+    info[0].value.type = PMIX_STRING;
+    info[0].value.data.string = (char *)px->job_tmpdir;
 
-    if ((rc = PMIx_server_init (NULL, &info, 1)) != PMIX_SUCCESS) {
+    strncpy (info[1].key, PMIX_SERVER_RANK, PMIX_MAX_KEYLEN);
+    info[1].value.type = PMIX_PROC_RANK;
+    info[1].value.data.rank = px->shell_rank;
+
+    if ((rc = PMIx_server_init (NULL, info, 2)) != PMIX_SUCCESS) {
         shell_warn ("PMIx_server_init: %s", PMIx_Error_string (rc));
         return -1;
     }

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -93,6 +93,7 @@ static int px_init (flux_plugin_t *p,
     }
 
     if (!(iv = infovec_create ())
+        || infovec_set_u32 (iv, PMIX_JOB_NUM_APPS, 1) < 0
         || infovec_set_str (iv, PMIX_TMPDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_LOCAL_SIZE, px->local_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_UNIV_SIZE, px->total_nprocs) < 0

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -93,6 +93,7 @@ static int px_init (flux_plugin_t *p,
     }
 
     if (!(iv = infovec_create ())
+        || infovec_set_u32 (iv, PMIX_LOCAL_SIZE, px->local_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_UNIV_SIZE, px->total_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_JOB_SIZE, px->total_nprocs) < 0)
         goto error;

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -93,6 +93,7 @@ static int px_init (flux_plugin_t *p,
     }
 
     if (!(iv = infovec_create ())
+        || infovec_set_str (iv, PMIX_TMPDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_LOCAL_SIZE, px->local_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_UNIV_SIZE, px->total_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_JOB_SIZE, px->total_nprocs) < 0)

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -93,6 +93,7 @@ static int px_init (flux_plugin_t *p,
     }
 
     if (!(iv = infovec_create ())
+        || infovec_set_u32 (iv, PMIX_UNIV_SIZE, px->total_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_JOB_SIZE, px->total_nprocs) < 0)
         goto error;
 

--- a/src/shell/plugins/maps.c
+++ b/src/shell/plugins/maps.c
@@ -1,0 +1,111 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* maps.c - construct inputs for PMIx_generate_ppn() and PMIx_generate_regex()
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <argz.h>
+#include <flux/shell.h>
+#include <flux/idset.h>
+#include <flux/hostlist.h>
+
+#include "maps.h"
+
+/* Iterate over each shell, creating an idset of ranks.
+ * Create a semicolon delimited list of idsets, where each entry
+ * represents a set of ranks on a shell.
+ * E.g. "0,1;2,3" means ranks 0,1 on shell 0; ranks 2,3 on shell 1.
+ */
+char *maps_proc_create (flux_shell_t *shell)
+{
+    int shell_size;
+    int base_rank = 0;
+    char *argz = NULL;
+    size_t argz_len = 0;
+    char *s;
+
+    if (flux_shell_info_unpack (shell, "{s:i}", "size", &shell_size) < 0)
+        return NULL;
+    for (int shell_rank = 0; shell_rank < shell_size; shell_rank++) {
+        int ntasks;
+        struct idset *ids;
+        char *s;
+        if (flux_shell_rank_info_unpack (shell,
+                                         shell_rank,
+                                         "{s:i}", "ntasks",
+                                         &ntasks) < 0)
+            return NULL;
+        if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW))
+            || idset_range_set (ids,
+                                base_rank,
+                                base_rank + ntasks - 1) < 0
+            || !(s = idset_encode (ids, 0))
+            || argz_add (&argz, &argz_len, s) != 0) {
+            idset_destroy (ids);
+            free (argz);
+            return NULL;
+        }
+        free (s);
+        idset_destroy (ids);
+        base_rank += ntasks;
+    }
+    argz_stringify (argz, argz_len, ';');
+    return argz;
+}
+
+/* First fetch the nodelist from R and convert it to a hostlist.
+ * Then encode the hostlist to a string with no range compression
+ * (we have to do that manually with an argz).
+ */
+char *maps_node_create (flux_shell_t *shell)
+{
+    json_t *nodelist;
+    size_t index;
+    json_t *value;
+    struct hostlist *hl = NULL;
+    char *argz = NULL;
+    size_t argz_len = 0;
+    const char *node;
+    char *hostname;
+    char *s;
+
+    if (flux_shell_info_unpack (shell,
+                                "{s:{s:{s:o}}}",
+                                "R",
+                                  "execution",
+                                    "nodelist", &nodelist) < 0)
+        return NULL;
+    if (!(hl = hostlist_create ()))
+        return NULL;
+    json_array_foreach (nodelist, index, value) {
+        const char *s = json_string_value (value);
+        if (!s || hostlist_append (hl, s) < 0)
+            goto error;
+    }
+    node = hostlist_first (hl);
+    while (node) {
+        if (argz_add (&argz, &argz_len, node) != 0)
+            goto error;
+        node = hostlist_next (hl);
+    }
+    hostlist_destroy (hl);
+    argz_stringify (argz, argz_len, ',');
+    return argz;
+error:
+    free (argz);
+    hostlist_destroy (hl);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/maps.h
+++ b/src/shell/plugins/maps.h
@@ -1,0 +1,21 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_MAPS_H
+#define _PX_MAPS_H
+
+#include <flux/shell.h>
+
+char *maps_proc_create (flux_shell_t *shell);
+char *maps_node_create (flux_shell_t *shell);
+
+#endif // _PX_MAPS_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/test/infovec.c
+++ b/src/shell/plugins/test/infovec.c
@@ -1,0 +1,182 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "infovec.h"
+
+void expansion (int count)
+{
+    struct infovec *iv;
+    int errors;
+
+    if (!(iv = infovec_create ()))
+        BAIL_OUT ("could not create infovec");
+
+    errors = 0;
+    for (int i = 0; i < count; i++) {
+        if (infovec_set_u32 (iv, "foo", i) < 0)
+            errors++;
+    }
+
+    ok (errors == 0,
+        "able to run infovec_set_u32 %dx with no errors", count);
+    ok (infovec_count (iv) == count,
+        "infovec_count returns expected size");
+
+    errors = 0;
+    for (int i = 0; i < count; i++) {
+        pmix_info_t *info = infovec_info (iv);
+        if (strcmp (info[i].key, "foo") != 0)
+            errors++;
+        if (info[i].value.type != PMIX_UINT32)
+            errors++;
+        if (info[i].value.data.uint32 != i)
+            errors++;
+    }
+    ok (errors == 0,
+        "infovec_info returns array with correct contents");
+
+    infovec_destroy (iv);
+}
+
+void basic (void)
+{
+    struct infovec *iv;
+    pmix_info_t *info;
+
+    lives_ok ({ infovec_destroy (NULL); },
+        "infovec_destroy iv=NULL doesn't crash");
+
+    iv = infovec_create ();
+    ok (iv != NULL,
+        "infovec_create works");
+    ok (infovec_count (iv) == 0,
+        "infovec_count returns 0");
+    lives_ok ({ infovec_destroy (iv); },
+        "infovec_destroy doesn't crash on empty array");
+
+    if (!(iv = infovec_create ()))
+        BAIL_OUT ("infovec_create failed");
+
+    /* u32 */
+    ok (infovec_set_u32 (iv, "foo", 42) == 0,
+        "infovec_set_u32 foo=42 works");
+    ok (infovec_count (iv) == 1,
+        "infovec_count returns 1");
+    info = infovec_info (iv);
+    ok (info != NULL,
+        "infovec_info returns non-NULL");
+    ok (strcmp (info[0].key, "foo") == 0,
+        "key is set correctly");
+    ok (info[0].value.type == PMIX_UINT32,
+        "value type is set correctly");
+    ok (info[0].value.data.uint32 == 42,
+        "value data is set correctly");
+
+    /* bool */
+    ok (infovec_set_bool (iv, "bar", true) == 0,
+        "infovec_set_bool bar=true works");
+    ok (infovec_count (iv) == 2,
+        "infovec_count returns 2");
+    info = infovec_info (iv);
+    ok (strcmp (info[1].key, "bar") == 0,
+        "key is set correctly");
+    ok (info[1].value.type == PMIX_BOOL,
+        "value type is set correctly");
+    ok (info[1].value.data.flag == true,
+        "value data is set correctly");
+
+    /* str */
+    ok (infovec_set_str (iv, "baz", "oof") == 0,
+        "infovec_set_str baz=oof works");
+    ok (infovec_count (iv) == 3,
+        "infovec_count returns 3");
+    info = infovec_info (iv);
+    ok (strcmp (info[2].key, "baz") == 0,
+        "key is set correctly");
+    ok (info[2].value.type == PMIX_STRING,
+        "value type is set correctly");
+    ok (info[2].value.data.string != NULL
+        && strcmp (info[2].value.data.string, "oof") == 0,
+        "value data is set correctly");
+
+    /* rank */
+    ok (infovec_set_rank (iv, "erg", PMIX_RANK_WILDCARD) == 0,
+        "infovec_set_rank erg=PMIX_RANK_WILDCARD works");
+    ok (infovec_count (iv) == 4,
+        "infovec_count returns 4");
+    info = infovec_info (iv);
+    ok (strcmp (info[3].key, "erg") == 0,
+        "key is set correctly");
+    ok (info[3].value.type == PMIX_PROC_RANK,
+        "value type is set correctly");
+    ok (info[3].value.data.rank == PMIX_RANK_WILDCARD,
+        "value data is set correctly");
+
+    infovec_destroy (iv);
+}
+
+void badarg (void)
+{
+    struct infovec *iv;
+
+    if (!(iv = infovec_create ()))
+        BAIL_OUT ("infovec_create failed");
+
+    errno = 0;
+    ok (infovec_set_u32 (NULL, "foo", 42) < 0 && errno == EINVAL,
+        "infovec_set_u32 iv=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_u32 (iv, NULL, 42) < 0 && errno == EINVAL,
+        "infovec_set_u32 key=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_bool (NULL, "foo", false) < 0 && errno == EINVAL,
+        "infovec_set_bool iv=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_bool (iv, NULL, true) < 0 && errno == EINVAL,
+        "infovec_set_bool key=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_rank (NULL, "foo", 2) < 0 && errno == EINVAL,
+        "infovec_set_rank iv=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_rank (iv, NULL, 2) < 0 && errno == EINVAL,
+        "infovec_set_rank key=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_str (NULL, "foo", "bar") < 0 && errno == EINVAL,
+        "infovec_set_str iv=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_str (iv, NULL, "bar") < 0 && errno == EINVAL,
+        "infovec_set_str key=NULL fails with EINVAL");
+    errno = 0;
+    ok (infovec_set_str (iv, "foo", NULL) < 0 && errno == EINVAL,
+        "infovec_set_str value=NULL fails with EINVAL");
+
+    infovec_destroy (iv);
+}
+
+int main (int argc, char **argv)
+{
+    plan (NO_PLAN);
+
+    basic ();
+    expansion (32); // make it > INFOVEC_CHUNK (8)
+    badarg ();
+
+    done_testing ();
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/src/getkey.c
+++ b/t/src/getkey.c
@@ -48,6 +48,12 @@ static void getkey (pmix_proc_t *proc, const char *key, optparse_t *p)
         case PMIX_UINT32:
             printf ("%lu\n", (unsigned long)val->data.uint32);
             break;
+        case PMIX_UINT16:
+            printf ("%hu\n", (unsigned short)val->data.uint16);
+            break;
+        case PMIX_PROC_RANK:
+            printf ("%lu\n", (unsigned long)val->data.rank);
+            break;
         case PMIX_STRING:
             printf ("%s\n", val->data.string);
             break;

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -80,6 +80,11 @@ test_expect_success 'pmix.local.size 2 procs 1 shell is 2' '
 		${GETKEY} --proc=* pmix.local.size >localsize.out &&
 	test_cmp localsize.exp localsize.out
 '
+test_expect_success 'pmix.tmpdir is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.tmpdir
+'
 
 test_expect_success 'pmix barrier works' '
 	run_timeout 30 flux mini run -n2 \

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -128,6 +128,15 @@ test_expect_success 'pmix.lrank is set' '
 		-ouserrc=$(pwd)/ompi_rc.lua \
 		${GETKEY} pmix.lrank
 '
+test_expect_success 'pmix.srv.rank is set to 0' '
+	cat >srvrank.exp <<-EOT &&
+	0
+	EOT
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} pmix.srv.rank >srvrank.out &&
+	test_cmp srvrank.exp srvrank.out
+'
 
 test_expect_success 'pmix barrier works' '
 	run_timeout 30 flux mini run -n2 \

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -98,6 +98,36 @@ test_expect_success 'pmix.nsdir is set' '
 		-ouserrc=$(pwd)/ompi_rc.lua \
 		${GETKEY} --proc=* pmix.nsdir
 '
+test_expect_success 'pmix.hname is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} pmix.hname
+'
+test_expect_success 'pmix.lpeers is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.lpeers
+'
+test_expect_success 'pmix.nlist is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.nlist
+'
+test_expect_success 'pmix.num.nodes is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.num.nodes
+'
+test_expect_success 'pmix.nodeid is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} pmix.nodeid
+'
+test_expect_success 'pmix.lrank is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} pmix.lrank
+'
 
 test_expect_success 'pmix barrier works' '
 	run_timeout 30 flux mini run -n2 \

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -144,4 +144,10 @@ test_expect_success 'pmix barrier works' '
 		${BARRIER}
 '
 
+test_expect_success 'pmix bizcard works' '
+	run_timeout 30 flux mini run -n2 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${BIZCARD} 1
+'
+
 test_done

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -40,6 +40,13 @@ test_expect_success 'server is listening on localhost' '
 	grep tcp4://127.0.0.1: uri.out
 '
 
+test_expect_success 'PMIX_SERVER_TMPDIR == FLUX_JOB_TMPDIR' '
+	grep FLUX_JOB_TMPDIR <env.out|cut -d= -f2 >jobtmp.out &&
+	grep PMIX_SERVER_TMPDIR <env.out|cut -d= -f2 >srvtmp.out &&
+	test -s jobtmp.out &&
+	test_cmp jobtmp.out srvtmp.out
+'
+
 test_expect_success 'pmix.job.size is set correctly on rank 0' '
 	cat >size.exp <<-EOT
 	2

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -93,6 +93,11 @@ test_expect_success 'pmix.job.napps is set to 1' '
 		-ouserrc=$(pwd)/ompi_rc.lua \
 		${GETKEY} --proc=* pmix.job.napps >napps.out
 '
+test_expect_success 'pmix.nsdir is set' '
+	run_timeout 30 flux mini run -n1 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.nsdir
+'
 
 test_expect_success 'pmix barrier works' '
 	run_timeout 30 flux mini run -n2 \

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -71,6 +71,15 @@ test_expect_success 'pmix.univ.size 2 procs is 3' '
 		${GETKEY} --proc=* pmix.univ.size >univ.out &&
 	test_cmp univ.exp univ.out
 '
+test_expect_success 'pmix.local.size 2 procs 1 shell is 2' '
+	cat >localsize.exp <<-EOT
+	2
+	EOT
+	run_timeout 30 flux mini run -n2 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.local.size >localsize.out &&
+	test_cmp localsize.exp localsize.out
+'
 
 test_expect_success 'pmix barrier works' '
 	run_timeout 30 flux mini run -n2 \

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -85,6 +85,14 @@ test_expect_success 'pmix.tmpdir is set' '
 		-ouserrc=$(pwd)/ompi_rc.lua \
 		${GETKEY} --proc=* pmix.tmpdir
 '
+test_expect_success 'pmix.job.napps is set to 1' '
+	cat >napps.exp <<-EOT
+	1
+	EOT
+	run_timeout 30 flux mini run -n2 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.job.napps >napps.out
+'
 
 test_expect_success 'pmix barrier works' '
 	run_timeout 30 flux mini run -n2 \

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -62,6 +62,15 @@ test_expect_success 'pmix.job.size is set correctly on rank 1' '
 		${GETKEY} --proc=* --rank=1 pmix.job.size >size1.out &&
 	test_cmp size.exp size1.out
 '
+test_expect_success 'pmix.univ.size 2 procs is 3' '
+	cat >univ.exp <<-EOT
+	2
+	EOT
+	run_timeout 30 flux mini run -n2 \
+		-ouserrc=$(pwd)/ompi_rc.lua \
+		${GETKEY} --proc=* pmix.univ.size >univ.out &&
+	test_cmp univ.exp univ.out
+'
 
 test_expect_success 'pmix barrier works' '
 	run_timeout 30 flux mini run -n2 \


### PR DESCRIPTION
Push data about the job into the pmix server so that various attributes can be accessed from the client side, mainly driven by what appears to be needed to get the business card exchange use case working on a single node, and also to populate attributes mentioned in the spec v5.0 B1.1.1 business card exchange description, and attributes that popped up while tracing hello world compiled with ompi-5.0.x launched with `prterun`.

I didn't cover all of those attributes, but enough that this is a good step forward for a PR.

I did ensure that each attribute I set on the server side had a measurable effect on the client side, and added tests reflecting that.