### PR TITLE
implement fence callback

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 SUBDIRS = \
 	src/common/libtap \
+	src/common/libccan \
 	src/shell/plugins \
 	t
 

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,7 @@ AC_SUBST(fluxplugin_ldflags)
 AC_CONFIG_FILES( \
   Makefile \
   src/common/libtap/Makefile \
+  src/common/libccan/Makefile \
   src/shell/plugins/Makefile \
   t/Makefile \
   t/sharness.d/00-setup.sh \

--- a/src/common/libccan/Makefile.am
+++ b/src/common/libccan/Makefile.am
@@ -1,0 +1,13 @@
+AM_CFLAGS = \
+        $(WARNING_CFLAGS) \
+        $(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+        $(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS =
+
+noinst_LTLIBRARIES = libccan.la
+libccan_la_SOURCES = \
+	ccan/base64/base64.c \
+	ccan/base64/base64.h

--- a/src/common/libccan/ccan/base64/LICENSE
+++ b/src/common/libccan/ccan/base64/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/BSD-MIT

--- a/src/common/libccan/ccan/base64/_info
+++ b/src/common/libccan/ccan/base64/_info
@@ -1,0 +1,41 @@
+#include "config.h"
+
+/**
+ * base64 - base64 encoding and decoding (rfc4648).
+ *
+ * base64 encoding is used to encode data in a 7-bit clean manner.
+ *  Commonly used for escaping data before encapsulation or transfer
+ *
+ * Example:
+ *      #include <stdio.h>
+ *      #include <string.h>
+ *      #include <ccan/base64/base64.h>
+ *
+ *      int main(int argc, char *argv[])
+ *      {
+ *      	char *base64_encoded_string;
+ *      	int i;
+ *
+ *      	// print the base64-encoded form of the program arguments
+ *      	for(i=1;i<argc;i++) {
+ *			size_t unencoded_length = strlen(argv[i]);
+ *      		size_t encoded_length = base64_encoded_length(unencoded_length);
+ *      		base64_encoded_string = malloc(encoded_length);
+ *      		base64_encode(base64_encoded_string, encoded_length,
+ *				 argv[i], unencoded_length);
+ *      		printf("%s\n", base64_encoded_string);
+ *      		free(base64_encoded_string);
+ *      	}
+ *
+ *      	return 0;
+ *      }
+ *
+ * License: BSD-MIT
+ */
+int main(int argc, char *argv[])
+{
+	if (argc != 2)
+		return 1;
+
+	return 1;
+}

--- a/src/common/libccan/ccan/base64/base64.c
+++ b/src/common/libccan/ccan/base64/base64.c
@@ -1,0 +1,253 @@
+/* Licensed under BSD-MIT - see LICENSE file for details */
+#include "base64.h"
+
+#include <errno.h>
+#include <string.h>
+#include <assert.h>
+#include <stdint.h>
+
+/**
+ * sixbit_to_b64 - maps a 6-bit value to the base64 alphabet
+ * @param map A base 64 map (see base64_init_map)
+ * @param sixbit Six-bit value to map
+ * @return a base 64 character
+ */
+static char sixbit_to_b64(const base64_maps_t *maps, const uint8_t sixbit)
+{
+	assert(sixbit <= 63);
+
+	return maps->encode_map[(unsigned char)sixbit];
+}
+
+/**
+ * sixbit_from_b64 - maps a base64-alphabet character to its 6-bit value
+ * @param maps A base 64 maps structure (see base64_init_maps)
+ * @param sixbit Six-bit value to map
+ * @return a six-bit value
+ */
+static int8_t sixbit_from_b64(const base64_maps_t *maps,
+			      const unsigned char b64letter)
+{
+	int8_t ret;
+
+	ret = maps->decode_map[(unsigned char)b64letter];
+	if (ret == (char)0xff) {
+		errno = EDOM;
+		return -1;
+	}
+
+	return ret;
+}
+
+bool base64_char_in_alphabet(const base64_maps_t *maps, const char b64char)
+{
+	return (maps->decode_map[(const unsigned char)b64char] != (char)0xff);
+}
+
+void base64_init_maps(base64_maps_t *dest, const char src[64])
+{
+	unsigned char i;
+
+	memcpy(dest->encode_map,src,64);
+	memset(dest->decode_map,0xff,256);
+	for (i=0; i<64; i++) {
+		dest->decode_map[(unsigned char)src[i]] = i;
+	}
+}
+
+size_t base64_encoded_length(size_t srclen)
+{
+	return ((srclen + 2) / 3) * 4;
+}
+
+void base64_encode_triplet_using_maps(const base64_maps_t *maps,
+				      char dest[4], const char src[3])
+{
+	char a = src[0];
+	char b = src[1];
+	char c = src[2];
+
+	dest[0] = sixbit_to_b64(maps, (a & 0xfc) >> 2);
+	dest[1] = sixbit_to_b64(maps, ((a & 0x3) << 4) | ((b & 0xf0) >> 4));
+	dest[2] = sixbit_to_b64(maps, ((c & 0xc0) >> 6) | ((b & 0xf) << 2));
+	dest[3] = sixbit_to_b64(maps, c & 0x3f);
+}
+
+void base64_encode_tail_using_maps(const base64_maps_t *maps, char dest[4],
+				   const char *src, const size_t srclen)
+{
+	char longsrc[3] = { 0 };
+
+	assert(srclen <= 3);
+
+	memcpy(longsrc, src, srclen);
+	base64_encode_triplet_using_maps(maps, dest, longsrc);
+	memset(dest+1+srclen, '=', 3-srclen);
+}
+
+ssize_t base64_encode_using_maps(const base64_maps_t *maps,
+				 char *dest, const size_t destlen,
+				 const char *src, const size_t srclen)
+{
+	size_t src_offset = 0;
+	size_t dest_offset = 0;
+
+	if (destlen < base64_encoded_length(srclen)) {
+		errno = EOVERFLOW;
+		return -1;
+	}
+
+	while (srclen - src_offset >= 3) {
+		base64_encode_triplet_using_maps(maps, &dest[dest_offset], &src[src_offset]);
+		src_offset += 3;
+		dest_offset += 4;
+	}
+
+	if (src_offset < srclen) {
+		base64_encode_tail_using_maps(maps, &dest[dest_offset], &src[src_offset], srclen-src_offset);
+		dest_offset += 4;
+	}
+
+	memset(&dest[dest_offset], '\0', destlen-dest_offset);
+
+	return dest_offset;
+}
+
+size_t base64_decoded_length(size_t srclen)
+{
+	return ((srclen+3)/4*3);
+}
+
+ssize_t base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3],
+				     const char src[4])
+{
+	signed char a;
+	signed char b;
+	signed char c;
+	signed char d;
+
+	a = sixbit_from_b64(maps, src[0]);
+	b = sixbit_from_b64(maps, src[1]);
+	c = sixbit_from_b64(maps, src[2]);
+	d = sixbit_from_b64(maps, src[3]);
+
+	if ((a == -1) || (b == -1) || (c == -1) || (d == -1)) {
+		return -1;
+	}
+
+	dest[0] = (a << 2) | (b >> 4);
+	dest[1] = ((b & 0xf) << 4) | (c >> 2);
+	dest[2] = ((c & 0x3) << 6) | d;
+
+	return 0;
+}
+
+
+ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
+				  const char * src, const size_t srclen)
+{
+	char longsrc[4];
+	int quartet_result;
+	size_t insize = srclen;
+
+	while (insize != 0 &&
+	       src[insize-1] == '=') { /* throw away padding symbols */
+		insize--;
+	}
+	if (insize == 0) {
+		return 0;
+	}
+	if (insize == 1) {
+		/* the input is malformed.... */
+		errno = EINVAL;
+		return -1;
+	}
+	memcpy(longsrc, src, insize);
+	memset(longsrc+insize, 'A', 4-insize);
+	quartet_result = base64_decode_quartet_using_maps(maps, dest, longsrc);
+	if (quartet_result == -1) {
+		return -1;
+	}
+
+	return insize - 1;
+}
+
+ssize_t base64_decode_using_maps(const base64_maps_t *maps,
+				 char *dest, const size_t destlen,
+				 const char *src, const size_t srclen)
+{
+	ssize_t dest_offset = 0;
+	ssize_t i;
+	ssize_t more;
+
+	if (destlen < base64_decoded_length(srclen)) {
+		errno = EOVERFLOW;
+		return -1;
+	}
+
+	for(i=0; srclen - i > 4; i+=4) {
+		if (base64_decode_quartet_using_maps(maps, &dest[dest_offset], &src[i]) == -1) {
+			return -1;
+		}
+		dest_offset += 3;
+	}
+
+	more = base64_decode_tail_using_maps(maps, &dest[dest_offset], &src[i], srclen - i);
+	if (more == -1) {
+		return -1;
+	}
+	dest_offset += more;
+
+	memset(&dest[dest_offset], '\0', destlen-dest_offset);
+
+	return dest_offset;
+}
+
+
+
+
+/**
+ * base64_maps_rfc4648 - pregenerated maps struct for rfc4648
+ */
+const base64_maps_t base64_maps_rfc4648 = {
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+
+  "\xff\xff\xff\xff\xff" /* 0 */					\
+  "\xff\xff\xff\xff\xff" /* 5 */					\
+  "\xff\xff\xff\xff\xff" /* 10 */					\
+  "\xff\xff\xff\xff\xff" /* 15 */					\
+  "\xff\xff\xff\xff\xff" /* 20 */					\
+  "\xff\xff\xff\xff\xff" /* 25 */					\
+  "\xff\xff\xff\xff\xff" /* 30 */					\
+  "\xff\xff\xff\xff\xff" /* 35 */					\
+  "\xff\xff\xff\x3e\xff" /* 40 */					\
+  "\xff\xff\x3f\x34\x35" /* 45 */					\
+  "\x36\x37\x38\x39\x3a" /* 50 */					\
+  "\x3b\x3c\x3d\xff\xff" /* 55 */					\
+  "\xff\xff\xff\xff\xff" /* 60 */					\
+  "\x00\x01\x02\x03\x04" /* 65 A */					\
+  "\x05\x06\x07\x08\x09" /* 70 */					\
+  "\x0a\x0b\x0c\x0d\x0e" /* 75 */					\
+  "\x0f\x10\x11\x12\x13" /* 80 */					\
+  "\x14\x15\x16\x17\x18" /* 85 */					\
+  "\x19\xff\xff\xff\xff" /* 90 */					\
+  "\xff\xff\x1a\x1b\x1c" /* 95 */					\
+  "\x1d\x1e\x1f\x20\x21" /* 100 */					\
+  "\x22\x23\x24\x25\x26" /* 105 */					\
+  "\x27\x28\x29\x2a\x2b" /* 110 */					\
+  "\x2c\x2d\x2e\x2f\x30" /* 115 */					\
+  "\x31\x32\x33\xff\xff" /* 120 */					\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 125 */			\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 155 */			\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 185 */			\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 215 */			\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"				\
+  "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 245 */
+};

--- a/src/common/libccan/ccan/base64/base64.h
+++ b/src/common/libccan/ccan/base64/base64.h
@@ -1,0 +1,241 @@
+/* Licensed under BSD-MIT - see LICENSE file for details */
+#ifndef CCAN_BASE64_H
+#define CCAN_BASE64_H
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+/**
+ * base64_maps_t - structure to hold maps for encode/decode
+ */
+typedef struct {
+	char encode_map[64];
+	signed char decode_map[256];
+} base64_maps_t;
+
+/**
+ * base64_encoded_length - Calculate encode buffer length
+ * @param srclen the size of the data to be encoded
+ * @note add 1 to this to get null-termination
+ * @return Buffer length required for encode
+ */
+size_t base64_encoded_length(size_t srclen);
+
+/**
+ * base64_decoded_length - Calculate decode buffer length
+ * @param srclen Length of the data to be decoded
+ * @note This does not return the size of the decoded data!  see base64_decode
+ * @return Minimum buffer length for safe decode
+ */
+size_t base64_decoded_length(size_t srclen);
+
+/**
+ * base64_init_maps - populate a base64_maps_t based on a supplied alphabet
+ * @param dest A base64 maps object
+ * @param src Alphabet to populate the maps from (e.g. base64_alphabet_rfc4648)
+ */
+void base64_init_maps(base64_maps_t *dest, const char src[64]);
+
+
+/**
+ * base64_encode_triplet_using_maps - encode 3 bytes into base64 using a specific alphabet
+ * @param maps Maps to use for encoding (see base64_init_maps)
+ * @param dest Buffer containing 3 bytes
+ * @param src Buffer containing 4 characters
+ */
+void base64_encode_triplet_using_maps(const base64_maps_t *maps,
+				      char dest[4], const char src[3]);
+
+/**
+ * base64_encode_tail_using_maps - encode the final bytes of a source using a specific alphabet
+ * @param maps Maps to use for encoding (see base64_init_maps)
+ * @param dest Buffer containing 4 bytes
+ * @param src Buffer containing srclen bytes
+ * @param srclen Number of bytes (<= 3) to encode in src
+ */
+void base64_encode_tail_using_maps(const base64_maps_t *maps, char dest[4],
+				   const char *src, size_t srclen);
+
+/**
+ * base64_encode_using_maps - encode a buffer into base64 using a specific alphabet
+ * @param maps Maps to use for encoding (see base64_init_maps)
+ * @param dest Buffer to encode into
+ * @param destlen Length of dest
+ * @param src Buffer to encode
+ * @param srclen Length of the data to encode
+ * @return Number of encoded bytes set in dest. -1 on error (and errno set)
+ * @note dest will be nul-padded to destlen (past any required padding)
+ * @note sets errno = EOVERFLOW if destlen is too small
+ */
+ssize_t base64_encode_using_maps(const base64_maps_t *maps,
+				 char *dest, size_t destlen,
+				 const char *src, size_t srclen);
+
+/*
+ * base64_char_in_alphabet - returns true if character can be part of an encoded string
+ * @param maps A base64 maps object (see base64_init_maps)
+ * @param b64char Character to check
+ */
+bool base64_char_in_alphabet(const base64_maps_t *maps, char b64char);
+
+/**
+ * base64_decode_using_maps - decode a base64-encoded string using a specific alphabet
+ * @param maps A base64 maps object (see base64_init_maps)
+ * @param dest Buffer to decode into
+ * @param destlen length of dest
+ * @param src the buffer to decode
+ * @param srclen the length of the data to decode
+ * @return Number of decoded bytes set in dest. -1 on error (and errno set)
+ * @note dest will be nul-padded to destlen
+ * @note sets errno = EOVERFLOW if destlen is too small
+ * @note sets errno = EDOM if src contains invalid characters
+ */
+ssize_t base64_decode_using_maps(const base64_maps_t *maps,
+				 char *dest, size_t destlen,
+				 const char *src, size_t srclen);
+
+/**
+ * base64_decode_quartet_using_maps - decode 4 bytes from base64 using a specific alphabet
+ * @param maps A base64 maps object (see base64_init_maps)
+ * @param dest Buffer containing 3 bytes
+ * @param src Buffer containing 4 bytes
+ * @return Number of decoded bytes set in dest. -1 on error (and errno set)
+ * @note sets errno = EDOM if src contains invalid characters
+ */
+ssize_t base64_decode_quartet_using_maps(const base64_maps_t *maps,
+				         char dest[3], const char src[4]);
+
+/**
+ * base64_decode_tail_using_maps - decode the final bytes of a base64 string using a specific alphabet
+ * @param maps A base64 maps object (see base64_init_maps)
+ * @param dest Buffer containing 3 bytes
+ * @param src Buffer containing 4 bytes - padded with '=' as required
+ * @param srclen Number of bytes to decode in src
+ * @return Number of decoded bytes set in dest. -1 on error (and errno set)
+ * @note sets errno = EDOM if src contains invalid characters
+ * @note sets errno = EINVAL if src is an invalid base64 tail
+ */
+ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
+				      const char *src, size_t srclen);
+
+
+/* the rfc4648 functions: */
+
+extern const base64_maps_t base64_maps_rfc4648;
+
+/**
+ * base64_encode - Encode a buffer into base64 according to rfc4648
+ * @param dest Buffer to encode into
+ * @param destlen Length of the destination buffer
+ * @param src Buffer to encode
+ * @param srclen Length of the data to encode
+ * @return Number of encoded bytes set in dest. -1 on error (and errno set)
+ * @note dest will be nul-padded to destlen (past any required padding)
+ * @note sets errno = EOVERFLOW if destlen is too small
+ *
+ * This function encodes src according to http://tools.ietf.org/html/rfc4648
+ *
+ * Example:
+ *	size_t encoded_length;
+ *	char dest[100];
+ *	const char *src = "This string gets encoded";
+ *	encoded_length = base64_encode(dest, sizeof(dest), src, strlen(src));
+ *	printf("Returned data of length %zd @%p\n", encoded_length, &dest);
+ */
+static inline
+ssize_t base64_encode(char *dest, size_t destlen,
+		      const char *src, size_t srclen)
+{
+	return base64_encode_using_maps(&base64_maps_rfc4648,
+					dest, destlen, src, srclen);
+}
+
+/**
+ * base64_encode_triplet - encode 3 bytes into base64 according to rfc4648
+ * @param dest Buffer containing 4 bytes
+ * @param src Buffer containing 3 bytes
+ */
+static inline
+void base64_encode_triplet(char dest[4], const char src[3])
+{
+	base64_encode_triplet_using_maps(&base64_maps_rfc4648, dest, src);
+}
+
+/**
+ * base64_encode_tail - encode the final bytes of a source according to rfc4648
+ * @param dest Buffer containing 4 bytes
+ * @param src Buffer containing srclen bytes
+ * @param srclen Number of bytes (<= 3) to encode in src
+ */
+static inline
+void base64_encode_tail(char dest[4], const char *src, size_t srclen)
+{
+	base64_encode_tail_using_maps(&base64_maps_rfc4648, dest, src, srclen);
+}
+
+
+/**
+ * base64_decode - decode An rfc4648 base64-encoded string
+ * @param dest Buffer to decode into
+ * @param destlen Length of the destination buffer
+ * @param src Buffer to decode
+ * @param srclen Length of the data to decode
+ * @return Number of decoded bytes set in dest. -1 on error (and errno set)
+ * @note dest will be nul-padded to destlen
+ * @note sets errno = EOVERFLOW if destlen is too small
+ * @note sets errno = EDOM if src contains invalid characters
+ *
+ * This function decodes the buffer according to
+ * http://tools.ietf.org/html/rfc4648
+ *
+ * Example:
+ *	size_t decoded_length;
+ *	char ret[100];
+ *	const char *src = "Zm9vYmFyYmF6";
+ *	decoded_length = base64_decode(ret, sizeof(ret), src, strlen(src));
+ *	printf("Returned data of length %zd @%p\n", decoded_length, &ret);
+ */
+static inline
+ssize_t base64_decode(char *dest, size_t destlen,
+		      const char *src, size_t srclen)
+{
+	return base64_decode_using_maps(&base64_maps_rfc4648,
+					dest, destlen, src, srclen);
+}
+
+/**
+ * base64_decode_quartet - decode the first 4 characters in src into dest
+ * @param dest Buffer containing 3 bytes
+ * @param src Buffer containing 4 characters
+ * @return Number of decoded bytes set in dest. -1 on error (and errno set)
+ * @note sets errno = EDOM if src contains invalid characters
+ */
+static inline
+ssize_t base64_decode_quartet(char dest[3], const char src[4])
+{
+	return base64_decode_quartet_using_maps(&base64_maps_rfc4648,
+						dest, src);
+}
+
+/**
+ * @brief decode the final bytes of a base64 string from src into dest
+ * @param dest Buffer containing 3 bytes
+ * @param src Buffer containing 4 bytes - padded with '=' as required
+ * @param srclen Number of bytes to decode in src
+ * @return Number of decoded bytes set in dest. -1 on error (and errno set)
+ * @note sets errno = EDOM if src contains invalid characters
+ * @note sets errno = EINVAL if src is an invalid base64 tail
+ */
+static inline
+ssize_t base64_decode_tail(char dest[3], const char *src, size_t srclen)
+{
+	return base64_decode_tail_using_maps(&base64_maps_rfc4648,
+					     dest, src, srclen);
+}
+
+/* end rfc4648 functions */
+
+
+
+#endif /* CCAN_BASE64_H */

--- a/src/common/libccan/ccan/base64/test/moretap.h
+++ b/src/common/libccan/ccan/base64/test/moretap.h
@@ -1,0 +1,96 @@
+#ifndef _BASE64_MORETAP_H
+#define _BASE64_MORETAP_H
+
+#include <ccan/str/str.h>
+
+/**
+ * is_str - OK if strings are equal
+ * @e1: expression for the variable string
+ * @e2: expression for the expected string
+ *
+ * If the strings are equal, the test passes.
+ *
+ * Example:
+ *     is_str(give_me_a_fred(),"fred");
+ */
+static void _is_str(char *got,const char *expected, const char *got_string, const char *expected_string, const char *func, const char *file, int line) {
+	if (streq(expected,got)) {
+		_gen_result(1, func, file, line,"%s eq %s",
+			    got_string,expected_string);
+	} else {
+		_gen_result(0, func, file, line,"%s eq %s",
+			    got_string,expected_string);
+		diag("Expected: %s",expected);
+		diag("     Got: %s",got);
+	}
+}
+# define is_str(got,expected) _is_str(got,expected,#got,#expected,__func__, __FILE__, __LINE__)
+
+
+/**
+ * is_int - OK if arguments are equal when cast to integers
+ * @e1: expression for the number
+ * @e2: expression for the expected number
+ *
+ * If the numbers are equal, the test passes.
+ *
+ * Example:
+ *     is_int(give_me_17(),17);
+ */
+# define is_int(e1,e2 ...)						\
+  (((int)e1)==((int)e2) ?						\
+   _gen_result(1, __func__, __FILE__, __LINE__,"%s == %s",#e1,#e2) :	\
+   (_gen_result(0, __func__, __FILE__, __LINE__,"%s == %s",#e1,#e2)) || (diag("Expected: %d",e2),diag("     Got: %d",e1),0)) /* diag is void; note commas. */
+
+
+
+/**
+ * is_mem - OK if arguments are identical up to length @e3
+ * @e1: expression for the buffer
+ * @e2: expression for the expected buffer
+ * @e2: length to compare in buffers
+ *
+ * If the buffers are equal up to @e2, the test passes.
+ *
+ * Example:
+ *     is_mem(give_me_foo(),"foo",3);
+ */
+static void _is_mem(const char *got, const char *expected, const size_t len,
+	      const char *got_string, const char *expected_string, const char *len_string,
+	      const char *func, const char *file, int line) {
+	size_t offset = 0;
+
+	for (offset=0; offset<len; offset++) {
+		if (got[offset] != expected[offset]) {
+			_gen_result(0, func, file, line,"%s eq %s",got_string,expected_string);
+			/* diag("Expected: %s",e2); */
+			/* diag("     Got: %s",e1); */
+			diag("Buffers differ at offset %zd (got=0x%02x expected=0x%02x)",
+			     offset,got[offset],expected[offset]);
+			return;
+		}
+	}
+
+	_gen_result(1, __func__, __FILE__, __LINE__,"%s eq %s",
+		    expected_string,got_string);
+}
+# define is_mem(got,expected,len) \
+	_is_mem(got,expected,len,#got,#expected,#len,__func__, __FILE__, __LINE__)
+
+/**
+ * is_size_t - OK if arguments are equal when cast to size_t
+ * @e1: expression for the number
+ * @e2: expression for the expected number
+ *
+ * If the numbers are equal, the test passes.
+ *
+ * Example:
+ *     is_size_t(give_me_17(),17);
+ */
+# define is_size_t(e1,e2 ...)						\
+  ((size_t)(e1)==((size_t)e2) ?						\
+   _gen_result(1, __func__, __FILE__, __LINE__,"%s == %s",#e1,#e2) :	\
+   (_gen_result(0, __func__, __FILE__, __LINE__,			\
+		"%s == %s",#e1,#e2)) || (diag("Expected: %zd",(size_t)e2),diag("     Got: %zd",(size_t)e1),0)) /* diag is void; note commas. */
+
+#endif

--- a/src/common/libccan/ccan/base64/test/run.c
+++ b/src/common/libccan/ccan/base64/test/run.c
@@ -1,0 +1,359 @@
+/* Start of run.c test */
+#include "config.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <ccan/base64/base64.h>
+#include <ccan/tap/tap.h>
+
+#include <ccan/base64/base64.c>
+#include "moretap.h"
+
+static void * xmalloc(size_t size);
+
+/* not defined in terms of test_encode_using_maps so we cross
+   appropriate paths in library */
+#define test_encode(src,srclen,expected)			\
+	do {							\
+		size_t destlen;					\
+		char * dest;					\
+		destlen = base64_encoded_length(srclen);	\
+		destlen++; /* null termination */		\
+		dest = xmalloc(destlen);			\
+		ok1(base64_encode(dest,destlen,src,srclen) != -1);	\
+		is_str(dest,expected);					\
+		free(dest);						\
+	} while (0)
+
+#define test_encode_using_alphabet(alphastring,src,srclen,expected)	\
+	do {								\
+		size_t destlen;						\
+		char * dest;						\
+		base64_maps_t maps;				\
+		base64_init_maps(&maps,alphastring);		\
+		destlen = base64_encoded_length(srclen);		\
+		destlen++; /* null termination */		\
+		dest = xmalloc(destlen);				\
+		ok1(base64_encode_using_maps(&maps,dest,destlen,src,srclen) != -1); \
+		is_str(dest,expected);					\
+		free(dest);						\
+	} while (0)
+
+/* not defined in terms of test_decode_using_alphabet so we cross
+   appropriate paths in library */
+#define test_decode(src,srclen,expected,expectedlen)			\
+	do {								\
+		size_t destlen;						\
+		size_t bytes_used;					\
+		char * dest;						\
+		destlen = base64_decoded_length(srclen);		\
+		dest = xmalloc(destlen);				\
+		ok1((bytes_used = base64_decode(dest,destlen,src,srclen)) != -1); \
+		is_size_t(bytes_used,expectedlen);			\
+		is_mem(dest,expected,bytes_used);			\
+		free(dest);						\
+	} while (0)
+
+#define test_decode_using_alphabet(alphastring,src,srclen,expected,expectedlen) \
+	do {								\
+		size_t destlen;						\
+		size_t bytes_used;					\
+		char * dest;						\
+		base64_maps_t maps;				\
+									\
+		base64_init_maps(&maps,alphastring);		\
+		destlen = base64_decoded_length(srclen);		\
+		dest = xmalloc(destlen);				\
+		ok1((bytes_used = base64_decode_using_maps(&maps,dest,destlen,src,srclen)) != -1); \
+		is_size_t(bytes_used,expectedlen);			\
+		is_mem(dest,expected,bytes_used);			\
+		free(dest);						\
+	} while (0)
+
+#define check_bad_range_decode(stuff_to_test,stufflen)	\
+do {							\
+	char dest[10];							\
+	errno = 0;							\
+	is_size_t(base64_decode(dest,sizeof(dest),stuff_to_test,(size_t)stufflen), \
+		  (size_t)-1);						\
+	is_int(errno,EDOM);						\
+} while (0)
+
+int
+main(int argc, char *argv[])
+{
+	plan_tests(131);
+
+	is_size_t(base64_encoded_length(0),(size_t)0);
+	is_size_t(base64_encoded_length(1),(size_t)4);
+	is_size_t(base64_encoded_length(2),(size_t)4);
+	is_size_t(base64_encoded_length(3),(size_t)4);
+	is_size_t(base64_encoded_length(512),(size_t)684);
+
+	/* straight from page 11 of http://tools.ietf.org/html/rfc4648 */
+	test_encode("",0,"");
+	test_encode("f",1,"Zg==");
+	test_encode("fo",2,"Zm8=");
+
+	test_encode("foo",3,"Zm9v");
+	test_encode("foob",4,"Zm9vYg==");
+	test_encode("fooba",5,"Zm9vYmE=");
+	test_encode("foobar",6,"Zm9vYmFy");
+
+	/* a few more */
+	test_encode("foobarb",7,"Zm9vYmFyYg==");
+	test_encode("foobarba",8,"Zm9vYmFyYmE=");
+	test_encode("foobarbaz",9,"Zm9vYmFyYmF6");
+
+	test_encode("foobart",7,"Zm9vYmFydA==");
+
+	test_encode("abcdefghijklmnopqrstuvwxyz",26,"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=");
+	test_encode("\x05\x05\x01\x00\x07",5,"BQUBAAc=");
+
+	test_encode("FOO",3,"Rk9P");
+	test_encode("Z",1,"Wg==");
+
+	/* decode testing */
+
+	test_decode("",0,"",0);
+	test_decode("Zg==",4,"f",1);
+	test_decode("Zm8=",4,"fo",2);
+	test_decode("Zm9v",4,"foo",3);
+	test_decode("Zm9vYg==",8,"foob",4);
+	test_decode("Zm9vYmE=",8,"fooba",5);
+	test_decode("Zm9vYmFy",8,"foobar",6);
+	test_decode("Zm9vYmFyYg==",12,"foobarb",7);
+	test_decode("Zm9vYmFyYmE=",12,"foobarba",8);
+	test_decode("Zm9vYmFyYmF6",12,"foobarbaz",9);
+
+	test_decode("Rk9P",4,"FOO",3);
+
+	test_decode("Wg==",4,"Z",1);
+	test_decode("AA==",4,"\0",1);
+	test_decode("AAA=",4,"\0\0",2);
+
+	{
+		const char *binary = "\x01\x00\x03";
+		const size_t binarylen = 3;
+
+		char * decoded;
+		char * encoded;
+		size_t encoded_len;
+		size_t decoded_len;
+		size_t decoded_space_required;
+
+		size_t encoded_space_required = base64_encoded_length(binarylen);
+		encoded_space_required++; /* null termination */
+		encoded = xmalloc(encoded_space_required);
+		encoded_len = base64_encode(encoded,encoded_space_required,binary,binarylen);
+		is_mem(encoded,"AQAD",encoded_len);
+
+		decoded_space_required = base64_decoded_length(encoded_len);
+		decoded = xmalloc(decoded_space_required);
+		decoded_len = base64_decode(decoded,decoded_space_required,encoded,encoded_len);
+		is_size_t(decoded_len,binarylen);
+		is_mem(binary,decoded,decoded_len);
+	}
+
+	/* some expected encode failures: */
+	{
+		size_t destlen = 1;
+		char dest[destlen];
+		errno = 0;
+		is_size_t(base64_encode(dest,destlen,"A",1),(size_t)-1);
+		is_int(errno,EOVERFLOW);
+	}
+
+	/* some expected decode failures: */
+	{
+		base64_maps_t maps;
+		const char * src = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+		base64_init_maps(&maps,src);
+
+		is_int(sixbit_from_b64(&maps,'\xfe'),(signed char)-1);
+		is_int(errno,EDOM);
+	}
+	{
+		size_t destlen = 10;
+		char dest[destlen];
+		errno = 0;
+		is_size_t(base64_decode(dest,destlen,"A",1),(size_t)-1);
+		is_int(errno,EINVAL);
+	}
+	{
+		size_t destlen = 1;
+		char dest[destlen];
+		errno = 0;
+		is_size_t(base64_decode(dest,destlen,"A",1),(size_t)-1);
+		is_int(errno,EOVERFLOW);
+	}
+	{
+		/* (char)1 is not a valid base64 character: */
+		check_bad_range_decode("A\x01",2);
+		/* (char)255 is not a valid base64 character: (char is signed on most platforms, so this is actually < 0 */
+		check_bad_range_decode("\xff""A",2);
+		check_bad_range_decode("A\xff",2);
+		check_bad_range_decode("AA\xff",3);
+		check_bad_range_decode("A\xff""A",3);
+		check_bad_range_decode("\xff""AA",3);
+		check_bad_range_decode("AAA\xff",4);
+		check_bad_range_decode("\xff\x41\x41\x41\x41",5);
+		check_bad_range_decode("A\xff\x41\x41\x41\x41",6);
+		check_bad_range_decode("AA\xff\x41\x41\x41\x41",7);
+		check_bad_range_decode("AAA\xff\x41\x41\x41\x41",8);
+	}
+	/* trigger some failures in the sixbit-to-b64 encoder: */
+	/* this function now aborts rather than returning -1/setting errno */
+	/* { */
+	/* 	is_int(sixbit_to_b64(base64_maps_rfc4648,'\x70'),(char)-1); */
+	/* 	is_int(sixbit_to_b64(base64_maps_rfc4648,'\xff'),(char)-1); */
+	/* } */
+	/* following tests all of the mapping from b64 chars to 6-bit values: */
+	test_decode("//+FwHRSRIsFU2IhAEGD+AMPhOA=",28,"\xff\xff\x85\xc0\x74\x52\x44\x8b\x05\x53\x62\x21\x00\x41\x83\xf8\x03\x0f\x84\xe0",20);
+	test_encode("\xff\xff\x85\xc0\x74\x52\x44\x8b\x05\x53\x62\x21\x00\x41\x83\xf8\x03\x0f\x84\xe0",20,"//+FwHRSRIsFU2IhAEGD+AMPhOA=");
+
+
+	/* check the null-padding stuff */
+	{
+		size_t destlen = 8;
+		char dest[destlen];
+		memset(dest,'\1',sizeof(dest));
+		is_size_t(base64_encode(dest,destlen,"A",1),(size_t)4);
+		is_mem(&dest[4],"\0\0\0\0",4);
+	}
+	{
+		size_t destlen = 3;
+		char dest[destlen];
+		memset(dest,'\1',sizeof(dest));
+		is_size_t(base64_decode(dest,destlen,"Wg==",4), 1);
+		is_mem(&dest[1],"\0",2);
+	}
+
+	/* test encoding using different alphabets */
+	{
+		char alphabet_fs_safe[64];
+		memcpy(alphabet_fs_safe,base64_maps_rfc4648.encode_map,sizeof(alphabet_fs_safe));
+		alphabet_fs_safe[62] = '-';
+		alphabet_fs_safe[63] = '_';
+		test_encode_using_alphabet(alphabet_fs_safe,"\xff\xff\x85\xc0\x74\x52\x44\x8b\x05\x53\x62\x21\x00\x41\x83\xf8\x03\x0f\x84\xe0",20,"__-FwHRSRIsFU2IhAEGD-AMPhOA=");
+	}
+
+	/* test decoding using different alphabets */
+	{
+		char alphabet_fs_safe[64];
+		#define src "__-FwHRSRIsFU2IhAEGD-AMPhOA="
+		#define expected "\xff\xff\x85\xc0\x74\x52\x44\x8b\x05\x53\x62\x21\x00\x41\x83\xf8\x03\x0f\x84\xe0"
+
+		memcpy(alphabet_fs_safe,base64_maps_rfc4648.encode_map,sizeof(alphabet_fs_safe));
+		alphabet_fs_safe[62] = '-';
+		alphabet_fs_safe[63] = '_';
+
+		test_decode_using_alphabet(alphabet_fs_safe,src,strlen(src),expected,20);
+		#undef src
+		#undef expected
+	}
+
+	/* explicitly test the non-maps encode_triplet and
+	   encode_tail functions */
+	{
+		size_t destlen = 4;
+		char dest[destlen];
+		const char *src = "AB\04";
+		memset(dest,'\1',sizeof(dest));
+		base64_encode_triplet(dest,src);
+		is_mem(dest,"QUIE",sizeof(dest));
+	}
+	{
+		size_t destlen = 4;
+		char dest[destlen];
+		const char *src = "A";
+		memset(dest,'\1',sizeof(dest));
+		base64_encode_tail(dest,src,strlen(src));
+		is_mem(dest,"QQ==",sizeof(dest));
+	}
+
+	/* test the alphabet inversion */
+	{
+		base64_maps_t dest;
+		const char expected_inverse[] =
+			"\xff\xff\xff\xff\xff" /* 0 */
+			"\xff\xff\xff\xff\xff" /* 5 */
+			"\xff\xff\xff\xff\xff" /* 10 */
+			"\xff\xff\xff\xff\xff" /* 15 */
+			"\xff\xff\xff\xff\xff" /* 20 */
+			"\xff\xff\xff\xff\xff" /* 25 */
+			"\xff\xff\xff\xff\xff" /* 30 */
+			"\xff\xff\xff\xff\xff" /* 35 */
+			"\xff\xff\xff\x3e\xff" /* 40 */
+			"\xff\xff\x3f\x34\x35" /* 45 - */
+			"\x36\x37\x38\x39\x3a" /* 50 */
+			"\x3b\x3c\x3d\xff\xff" /* 55 */
+			"\xff\xff\xff\xff\xff" /* 60 */
+			"\x00\x01\x02\x03\x04" /* 65 A */
+			"\x05\x06\x07\x08\x09" /* 70 */
+			"\x0a\x0b\x0c\x0d\x0e" /* 75 */
+			"\x0f\x10\x11\x12\x13" /* 80 */
+			"\x14\x15\x16\x17\x18" /* 85 */
+			"\x19\xff\xff\xff\xff" /* 90 */
+			"\xff\xff\x1a\x1b\x1c" /* 95 _ */
+			"\x1d\x1e\x1f\x20\x21" /* 100 */
+			"\x22\x23\x24\x25\x26" /* 105 */
+			"\x27\x28\x29\x2a\x2b" /* 110 */
+			"\x2c\x2d\x2e\x2f\x30" /* 115 */
+			"\x31\x32\x33\xff\xff" /* 120 */
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 125 */
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 155 */
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 185 */
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 215 */
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" /* 245 */
+			;
+		const char * src = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+		base64_init_maps(&dest, src);
+		is_mem((const char *)dest.decode_map, expected_inverse, 256);
+		ok1(base64_char_in_alphabet(&dest,'A'));
+		ok1(!base64_char_in_alphabet(&dest,'\n'));
+	}
+
+	/* explicitly test the non-alpha decode_tail and decode_quartet */
+	{
+		char dest[4];
+		const char *src = "QQ==";
+		const char * expected = "A";
+		memset(dest, '%', sizeof(dest));
+		base64_decode_tail(dest,src,4);
+		is_mem(dest, expected, 1);
+	}
+	{
+		char dest[4];
+		const char *src = "Zm9v";
+		const char * expected = "foo";
+		memset(dest, '%', sizeof(dest));
+		base64_decode_quartet(dest,src);
+		is_mem(dest, expected, 1);
+	}
+
+	exit(exit_status());
+}
+
+static void * xmalloc(size_t size)
+{
+	char * ret;
+	ret = malloc(size);
+	if (ret == NULL) {
+		perror("malloc");
+		abort();
+	}
+	return ret;
+}
+
+/* End of run.c test */

--- a/src/common/libccan/licenses/BSD-MIT
+++ b/src/common/libccan/licenses/BSD-MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -16,7 +16,9 @@ pmix_la_SOURCES = \
 	maps.h \
 	maps.c \
 	codec.h \
-	codec.c
+	codec.c \
+	interthread.h \
+	interthread.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -18,7 +18,9 @@ pmix_la_SOURCES = \
 	codec.h \
 	codec.c \
 	interthread.h \
-	interthread.c
+	interthread.c \
+	exchange.h \
+	exchange.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -14,7 +14,9 @@ pmix_la_SOURCES = \
 	infovec.h \
 	infovec.c \
 	maps.h \
-	maps.c
+	maps.c \
+	codec.h \
+	codec.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \
@@ -27,17 +29,20 @@ pmix_la_LIBADD = \
 	$(PMIX_LIBS) \
 	$(FLUX_IDSET_LIBS) \
 	$(FLUX_HOSTLIST_LIBS) \
-	$(JANSSON_LIBS)
+	$(JANSSON_LIBS) \
+	$(top_builddir)/src/common/libccan/libccan.la
 pmix_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(fluxplugin_ldflags) \
 	-module
 
 TESTS = \
-	test_infovec.t
+	test_infovec.t \
+	test_codec.t
 
 test_ldadd = \
-	$(top_builddir)/src/common/libtap/libtap.la
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libccan/libccan.la
 
 test_ldflags = \
         -no-install
@@ -58,4 +63,18 @@ test_infovec_t_CPPFLAGS = \
 test_infovec_t_LDADD = \
         $(test_ldadd)
 test_infovec_t_LDFLAGS = \
+        $(test_ldflags)
+
+test_codec_t_SOURCES = \
+        codec.c \
+        codec.h \
+        test/codec.c
+test_codec_t_CPPFLAGS = \
+        $(PMIX_CFLAGS) \
+        $(JANSSON_CFLAGS) \
+        $(test_cppflags)
+test_codec_t_LDADD = \
+        $(test_ldadd) \
+	$(JANSSON_LIBS)
+test_codec_t_LDFLAGS = \
         $(test_ldflags)

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -20,7 +20,9 @@ pmix_la_SOURCES = \
 	interthread.h \
 	interthread.c \
 	exchange.h \
-	exchange.c
+	exchange.c \
+	fence.h \
+	fence.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \

--- a/src/shell/plugins/codec.c
+++ b/src/shell/plugins/codec.c
@@ -1,0 +1,446 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* codec.c - encode/decode functions betwen pmix data structures and json */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <jansson.h>
+#include <pmix_server.h>
+
+#include "src/common/libccan/ccan/base64/base64.h"
+
+#include "codec.h"
+
+json_t *codec_pointer_encode (void *ptr)
+{
+    return json_integer ((uintptr_t)ptr);
+}
+
+int codec_pointer_decode (json_t *o, void **ptr)
+{
+    if (!json_is_integer (o))
+        return -1;
+    *ptr = (void *)json_integer_value (o);
+    return 0;
+}
+
+json_t *codec_data_encode (const void *data, size_t length)
+{
+    int xlength = base64_encoded_length (length) + 1; // +1 for \0 term
+    char *xdata;
+    json_t *o = NULL;
+
+    if (!(xdata = malloc (xlength))
+        || base64_encode (xdata, xlength, data, length) < 0
+        || !(o = json_string_nocheck (xdata))) {
+        free (xdata);
+        return NULL;
+    }
+    free (xdata);
+    return o;
+}
+
+ssize_t codec_data_decode_bufsize (json_t *o)
+{
+    if (!json_is_string (o))
+        return -1;
+
+    int xlength = json_string_length (o);
+    size_t length = base64_decoded_length (xlength);
+
+    return length;
+}
+
+ssize_t codec_data_decode_tobuf (json_t *o, void *data, size_t length)
+{
+    if (!json_is_string (o))
+        return -1;
+
+    int xlength = json_string_length (o);
+    const void *xdata = json_string_value (o);
+
+    return base64_decode (data, length, xdata, xlength);
+}
+
+int codec_data_decode (json_t *o, void **datap, size_t *lengthp)
+{
+    ssize_t bufsize;
+    ssize_t length;
+    void *data;
+
+    if ((bufsize = codec_data_decode_bufsize (o)) < 0)
+        return -1;
+    if (!(data = malloc (bufsize))
+        || (length = codec_data_decode_tobuf (o, data, bufsize)) < 0) {
+        free (data);
+        return -1;
+    }
+    *datap = data;
+    *lengthp = length;
+    return 0;
+}
+
+json_t *codec_proc_encode (const pmix_proc_t *proc)
+{
+    return json_pack ("{s:s s:i}",
+                      "nspace", proc->nspace,
+                      "rank", proc->rank);
+}
+
+int codec_proc_decode (json_t *o, pmix_proc_t *proc)
+{
+    const char *nspace;
+    int rank;
+
+    if (json_unpack (o,
+                     "{s:s s:i}",
+                     "nspace", &nspace,
+                     "rank", &rank) < 0)
+        return -1;
+    proc->rank = rank;
+    strncpy (proc->nspace, nspace, PMIX_MAX_NSLEN);
+    proc->nspace[PMIX_MAX_NSLEN] = '\0';
+    return 0;
+}
+
+json_t *codec_proc_array_encode (const pmix_proc_t *procs, size_t nprocs)
+{
+    json_t *o;
+    json_t *entry;
+    int i;
+
+    if (!(o = json_array ()))
+        return NULL;
+    for (i = 0; i < nprocs; i++) {
+        if (!(entry = codec_proc_encode (&procs[i]))
+            || json_array_append_new (o, entry) < 0) {
+            json_decref (entry);
+            json_decref (o);
+            return NULL;
+        }
+    }
+    return o;
+}
+
+int codec_proc_array_decode (json_t *o, pmix_proc_t **procsp, size_t *nprocsp)
+{
+    pmix_proc_t *procs;
+    size_t nprocs = json_array_size (o);
+    size_t index;
+    json_t *value;
+
+    if (!json_is_array (o)
+        || !(procs = calloc (nprocs, sizeof (procs[0]))))
+        return -1;
+    json_array_foreach (o, index, value) {
+        if (codec_proc_decode (value, &procs[index]) < 0) {
+            free (procs);
+            return -1;
+        }
+    }
+    *procsp = procs;
+    *nprocsp = nprocs;
+    return 0;
+}
+
+json_t *codec_value_encode (const pmix_value_t *value)
+{
+    json_t *o = NULL;
+    json_t *data = NULL;
+
+    switch (value->type) {
+        case PMIX_BOOL:
+            data = value->data.flag ? json_true () : json_false ();
+            break;
+        case PMIX_BYTE:
+            data = json_integer (value->data.byte);
+            break;
+        case PMIX_STRING:
+            data = json_string (value->data.string);
+            break;
+        case PMIX_SIZE:
+            data = json_integer (value->data.size);
+            break;
+        case PMIX_PID:
+            data = json_integer (value->data.pid);
+            break;
+        case PMIX_INT:
+            data = json_integer (value->data.integer);
+            break;
+        case PMIX_INT8:
+            data = json_integer (value->data.int8);
+            break;
+        case PMIX_INT16:
+            data = json_integer (value->data.int16);
+            break;
+        case PMIX_INT32:
+            data = json_integer (value->data.int32);
+            break;
+        case PMIX_INT64:
+            data = json_integer (value->data.int64);
+            break;
+        case PMIX_UINT:
+            data = json_integer (value->data.uint);
+            break;
+        case PMIX_UINT8:
+            data = json_integer (value->data.uint8);
+            break;
+        case PMIX_UINT16:
+            data = json_integer (value->data.uint16);
+            break;
+        case PMIX_UINT32:
+            data = json_integer (value->data.uint32);
+            break;
+        case PMIX_UINT64:
+            data = json_integer (value->data.uint64);
+            break;
+        case PMIX_PROC_RANK:
+            data = json_integer (value->data.rank);
+            break;
+        case PMIX_FLOAT:
+            data = json_real (value->data.fval);
+            break;
+        case PMIX_DOUBLE:
+            data = json_real (value->data.dval);
+            break;
+        case PMIX_TIMEVAL: // struct timeval
+            data = json_pack ("{s:I s:I}",
+                              "sec", (intmax_t)value->data.tv.tv_sec,
+                              "usec", (intmax_t)value->data.tv.tv_usec);
+            break;
+        case PMIX_TIME: // time_t
+            data = json_integer (value->data.time);
+            break;
+        case PMIX_STATUS: // pmix_status_t
+            data = json_integer (value->data.status);
+            break;
+        case PMIX_PROC: // pmix_proc_t *
+            data = codec_proc_encode (value->data.proc);
+            break;
+        default:
+            break; // leave data NULL for NULL return
+    }
+    if (data) {
+        o = json_pack ("{s:i s:O}",
+                       "type", value->type,
+                       "data", data);
+        json_decref (data);
+    }
+    return o;
+}
+
+void codec_value_release (pmix_value_t *value)
+{
+    switch (value->type) {
+        case PMIX_PROC:
+            free (value->data.proc);
+            break;
+        case PMIX_STRING:
+            free (value->data.string);
+            break;
+    }
+}
+
+/* N.B. for some types, memory is allocated and assigned to value->data
+ * that must be freed with codec_value_release().
+ */
+int codec_value_decode (json_t *o, pmix_value_t *value)
+{
+    int type;
+    json_t *data;
+
+    if (json_unpack (o,
+                     "{s:i s:o}",
+                     "type", &type,
+                     "data", &data) < 0)
+        return -1;
+    switch (type) {
+        case PMIX_BOOL:
+            value->data.flag = json_is_false (data) ? 0 : 1;
+            break;
+        case PMIX_BYTE:
+            value->data.byte = json_integer_value (data);
+            break;
+        case PMIX_STRING: {
+            char *cpy;
+            if (!(cpy = strdup (json_string_value (data))))
+                return -1;
+            value->data.string = cpy;
+            break;
+        }
+        case PMIX_SIZE:
+            value->data.size = json_integer_value (data);
+            break;
+        case PMIX_PID:
+            value->data.pid = json_integer_value (data);
+            break;
+        case PMIX_INT:
+            value->data.integer = json_integer_value (data);
+            break;
+        case PMIX_INT8:
+            value->data.int8 = json_integer_value (data);
+            break;
+        case PMIX_INT16:
+            value->data.int16 = json_integer_value (data);
+            break;
+        case PMIX_INT32:
+            value->data.int32 = json_integer_value (data);
+            break;
+        case PMIX_INT64:
+            value->data.int64 = json_integer_value (data);
+            break;
+        case PMIX_UINT:
+            value->data.uint = json_integer_value (data);
+            break;
+        case PMIX_UINT8:
+            value->data.uint8 = json_integer_value (data);
+            break;
+        case PMIX_UINT16:
+            value->data.uint16 = json_integer_value (data);
+            break;
+        case PMIX_UINT32:
+            value->data.uint32 = json_integer_value (data);
+            break;
+        case PMIX_UINT64:
+            value->data.uint64 = json_integer_value (data);
+            break;
+        case PMIX_PROC_RANK:
+            value->data.rank = json_integer_value (data);
+            break;
+        case PMIX_FLOAT:
+            value->data.fval = json_real_value (data);
+            break;
+        case PMIX_DOUBLE:
+            value->data.dval = json_real_value (data);
+            break;
+        case PMIX_TIMEVAL: {
+            json_int_t sec, usec;
+            if (json_unpack (data, "{s:I s:I}", &sec, &usec) < 0)
+                return -1;
+            value->data.tv.tv_sec = sec;
+            value->data.tv.tv_usec = usec;
+            break;
+        }
+        case PMIX_TIME: // time_t
+            value->data.time = json_integer_value (data);
+            break;
+        case PMIX_STATUS: // pmix_status_t
+            value->data.status = json_integer_value (data);
+            break;
+        case PMIX_PROC: {
+            pmix_proc_t *proc;
+            if (!(proc = calloc (1, sizeof (*proc)))
+                || codec_proc_decode (data, proc) < 0) {
+                free (proc);
+                return -1;
+            }
+            value->data.proc = proc;
+            break;
+        }
+        default:
+            return -1;
+    }
+    value->type = type;
+    return 0;
+}
+
+json_t *codec_info_encode (const pmix_info_t *info)
+{
+    json_t *o;
+    json_t *value;
+
+    if (!(value = codec_value_encode (&info->value)))
+        return NULL;
+    o = json_pack ("{s:s s:i s:O}",
+                   "key", info->key,
+                   "flags", info->flags,
+                   "value", value);
+    json_decref (value);
+    return o;
+}
+
+void codec_info_release (pmix_info_t *info)
+{
+    codec_value_release (&info->value);
+}
+
+int codec_info_decode (json_t *o, pmix_info_t *info)
+{
+    const char *key;
+    int flags;
+    json_t *xvalue;
+
+    if (json_unpack (o,
+                     "{s:s s:i s:o}",
+                     "key", &key,
+                     "flags", &flags,
+                     "value", &xvalue) < 0)
+        return -1;
+    if (codec_value_decode (xvalue, &info->value) < 0) // allocs mem
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->key[PMIX_MAX_KEYLEN] = '\0';
+    return 0;
+}
+
+json_t *codec_info_array_encode (const pmix_info_t *info, size_t ninfo)
+{
+    json_t *o;
+    json_t *entry;
+    int i;
+
+    if (!(o = json_array ()))
+        return NULL;
+    for (i = 0; i < ninfo; i++) {
+        if (!(entry = codec_info_encode (&info[i]))
+            || json_array_append_new (o, entry) < 0) {
+            json_decref (entry);
+            json_decref (o);
+            return NULL;
+        }
+    }
+    return o;
+}
+
+int codec_info_array_decode (json_t *o, pmix_info_t **infop, size_t *ninfop)
+{
+    pmix_info_t *info;
+    size_t ninfo = json_array_size (o);
+    size_t index;
+    json_t *value;
+
+    if (!json_is_array (o)
+        || !(info = calloc (ninfo, sizeof (info[0]))))
+        return -1;
+    json_array_foreach (o, index, value) {
+        if (codec_info_decode (value, &info[index]) < 0) {
+            free (info);
+            return -1;
+        }
+    }
+    *infop = info;
+    *ninfop = ninfo;
+    return 0;
+}
+
+void codec_info_array_destroy (pmix_info_t *info, size_t ninfo)
+{
+    if (info) {
+        size_t i;
+        for (i = 0; i < ninfo; i++)
+            codec_info_release (&info[i]);
+        free (info);
+    }
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/codec.h
+++ b/src/shell/plugins/codec.h
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <jansson.h>
+#include <pmix_server.h>
+
+#ifndef _PX_CODEC_H
+#define _PX_CODEC_H
+
+json_t *codec_pointer_encode (void *ptr);
+int codec_pointer_decode (json_t *o, void **ptr);
+
+json_t *codec_data_encode (const void *data, size_t length);
+int codec_data_decode (json_t *o, void **data, size_t *length);
+
+ssize_t codec_data_decode_bufsize (json_t *o);
+ssize_t codec_data_decode_tobuf (json_t *o, void *data, size_t buflen);
+
+json_t *codec_value_encode (const pmix_value_t *value);
+int codec_value_decode (json_t *o, pmix_value_t *value); // allocs internal mem
+void codec_value_release (pmix_value_t *value); // free internal mem from decode
+
+json_t *code_info_encode (const pmix_info_t *info);
+int codec_info_decode (json_t *o, pmix_info_t *info); // allocs internal mem
+void codec_info_release (pmix_info_t *info); // free internal mem from decode
+
+json_t *codec_proc_encode (const pmix_proc_t *proc);
+int codec_proc_decode (json_t *o, pmix_proc_t *proc);
+
+json_t *codec_proc_array_encode (const pmix_proc_t *procs, size_t nprocs);
+int codec_proc_array_decode (json_t *o, pmix_proc_t **procs, size_t *nprocs);
+
+json_t *codec_info_array_encode (const pmix_info_t *info, size_t ninfo);
+int codec_info_array_decode (json_t *o, pmix_info_t **info, size_t *ninfo);
+void codec_info_array_destroy (pmix_info_t *info, size_t ninfo);
+
+#endif // _PX_CODEC_H
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/exchange.c
+++ b/src/shell/plugins/exchange.c
@@ -1,0 +1,324 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* exchange.c - sync local dict across shells
+ *
+ * Derived from shell/pmi/pmi_exchange.c in flux-core.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "exchange.h"
+
+#define DEFAULT_TREE_K 2
+
+struct session {
+    json_t *dict;                   // container for gathered dictionary
+    exchange_f cb;                  // callback for exchange completion
+    void *cb_arg;
+
+    struct flux_msglist *requests;  // pending requests from children
+    flux_future_t *f;               // pending request to parent
+
+    struct exchange *xcg;
+    bool local;                     // exchange() was called on this shell
+    bool has_error;                 // an error occurred
+};
+
+struct exchange {
+    flux_shell_t *shell;
+    int size;
+    int rank;
+    uint32_t parent_rank;
+    int child_count;
+
+    struct session *session;
+};
+
+static void exchange_response_completion (flux_future_t *f, void *arg);
+
+/* borrow a couple of well tested functions from kary.c in flux-core
+ */
+#define KARY_NONE   (~(uint32_t)0)
+// Return the parent of i or KARY_NONE if i has no parent.
+static uint32_t kary_parentof (int k, uint32_t i)
+{
+    if (i == 0 || k <= 0)
+        return KARY_NONE;
+    if (k == 1)
+        return i - 1;
+    return (k + (i + 1) - 2) / k - 1;
+}
+// Return the jth child of i or KARY_NONE if i has no such child.
+static uint32_t kary_childof (int k, uint32_t size, uint32_t i, int j)
+{
+    uint32_t n;
+
+    if (k > 0 && j >= 0 && j < k) {
+        n = k*(i + 1) - (k - 2) + j - 1;
+        if (n < size)
+            return n;
+    }
+    return KARY_NONE;
+}
+
+static void session_destroy (struct session *ses)
+{
+    if (ses) {
+        int saved_errno = errno;
+        flux_msglist_destroy (ses->requests);
+        flux_future_destroy (ses->f);
+        json_decref (ses->dict);
+        free (ses);
+        errno = saved_errno;
+    }
+}
+
+static struct session *session_create (struct exchange *xcg)
+{
+    struct session *ses;
+
+    if (!(ses = calloc (1, sizeof (*ses))))
+        return NULL;
+    ses->xcg = xcg;
+    if (!(ses->requests = flux_msglist_create ()))
+        goto error;
+    if (!(ses->dict = json_object ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    return ses;
+error:
+    session_destroy (ses);
+    return NULL;
+}
+
+static void session_process (struct session *ses)
+{
+    struct exchange *xcg = ses->xcg;
+    flux_t *h = flux_shell_get_flux (ses->xcg->shell);
+    const flux_msg_t *msg;
+
+    if (ses->has_error)
+        goto done;
+
+    /* Awaiting self or child input?
+     */
+    if (!ses->local || flux_msglist_count (ses->requests) < xcg->child_count)
+        return;
+
+    /* Send exchange request, if needed.
+     */
+    if (xcg->rank > 0 && !ses->f) {
+        flux_future_t *f;
+
+        if (!(f = flux_shell_rpc_pack (xcg->shell,
+                                       "pmix-exchange",
+                                       xcg->parent_rank,
+                                       0,
+                                       "O",
+                                       ses->dict))
+                || flux_future_then (f,
+                                     -1,
+                                     exchange_response_completion,
+                                     xcg) < 0) {
+            flux_future_destroy (f);
+            shell_warn ("error sending pmi-exchange request");
+            ses->has_error = 1;
+            goto done;
+        }
+        ses->f = f;
+    }
+
+    /* Awaiting parent response?
+     */
+    if (ses->f && !flux_future_is_ready (ses->f))
+        return;
+
+    /* Send exchange response(s), if needed.
+     */
+    while ((msg = flux_msglist_pop (ses->requests))) {
+        if (flux_respond_pack (h, msg, "O", ses->dict) < 0) {
+            shell_warn ("error responding to pmi-exchange request");
+            flux_msg_decref (msg);
+            ses->has_error = 1;
+            goto done;
+        }
+        flux_msg_decref (msg);
+    }
+done:
+    ses->cb (xcg, ses->cb_arg);
+    session_destroy (ses);
+    xcg->session = NULL;
+}
+
+/* parent shell has responded to pmi-exchange request.
+ */
+static void exchange_response_completion (flux_future_t *f, void *arg)
+{
+    struct exchange *xcg = arg;
+    json_t *dict;
+
+    if (flux_rpc_get_unpack (f, "o", &dict) < 0) {
+        shell_warn ("pmi-exchange request: %s", future_strerror (f, errno));
+        xcg->session->has_error = 1;
+        goto done;
+    }
+    if (json_object_update (xcg->session->dict, dict) < 0) {
+        shell_warn ("pmi-exchange response handling failed to update dict");
+        xcg->session->has_error = 1;
+        goto done;
+    }
+done:
+    session_process (xcg->session);
+}
+
+/* child shell sent a pmi-exchange request
+ */
+static void exchange_request_cb (flux_t *h,
+                                 flux_msg_handler_t *mh,
+                                 const flux_msg_t *msg,
+                                 void *arg)
+{
+    struct exchange *xcg = arg;
+    json_t *dict;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg, NULL, "o", &dict) < 0)
+        goto error;
+    if (!xcg->session) {
+        if (!(xcg->session = session_create (xcg)))
+            goto error;
+    }
+    if (flux_msglist_count (xcg->session->requests) == xcg->child_count) {
+        errstr = "exchange received too many child requests";
+        errno = EINPROGRESS;
+        goto error;
+    }
+    if (json_object_update (xcg->session->dict, dict) < 0) {
+        errstr = "exchange request failed to update dict";
+        errno = ENOMEM;
+        goto error;
+    }
+    if (flux_msglist_append (xcg->session->requests, msg) < 0) {
+        errstr = "exchange request failed to save pending request";
+        goto error;
+    }
+    session_process (xcg->session);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        shell_warn ("error responding to pmi-exchange request: %s",
+                    flux_strerror (errno));
+}
+
+/* this shell is ready to exchange.
+ */
+int exchange (struct exchange *xcg, json_t *dict, exchange_f cb, void *arg)
+{
+    if (!xcg->session) {
+        if (!(xcg->session = session_create (xcg)))
+            return -1;
+    }
+    if (xcg->session->local) {
+        errno = EINPROGRESS;
+        return -1;
+    }
+    xcg->session->cb = cb;
+    xcg->session->cb_arg = arg;
+    xcg->session->local = 1;
+    if (json_object_update (xcg->session->dict, dict) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    session_process (xcg->session);
+    return 0;
+}
+
+/* Helper for exchange_create() - calculate the number of children of
+ * 'rank' in a 'size' tree of degree 'k'.
+ */
+static int child_count (int k, int rank, int size)
+{
+    int i;
+    int count = 0;
+
+    for (i = 0; i < k; i++) {
+        if (kary_childof (k, size, rank, i) != KARY_NONE)
+            count++;
+    }
+    return count;
+}
+
+struct exchange *exchange_create (flux_shell_t *shell, int k)
+{
+    struct exchange *xcg;
+
+    if (!(xcg = calloc (1, sizeof (*xcg))))
+        return NULL;
+    xcg->shell = shell;
+    if (flux_shell_info_unpack (shell,
+                                "{s:i s:i}",
+                                "size", &xcg->size,
+                                "rank", &xcg->rank) < 0)
+        goto error;
+    if (k <= 0)
+        k = DEFAULT_TREE_K;
+    else if (k > xcg->size) {
+        k = xcg->size;
+        if (xcg->rank == 0)
+            shell_warn ("requested exchange fanout too large, using k=%d", k);
+    }
+    else {
+        if (xcg->rank == 0)
+            shell_debug ("using k=%d", k);
+    }
+    xcg->parent_rank = kary_parentof (k, xcg->rank);
+    xcg->child_count = child_count (k, xcg->rank, xcg->size);
+
+    if (flux_shell_service_register (shell,
+                                     "pmix-exchange",
+                                     exchange_request_cb,
+                                     xcg) < 0)
+        goto error;
+    return xcg;
+error:
+    exchange_destroy (xcg);
+    return NULL;
+}
+
+void exchange_destroy (struct exchange *xcg)
+{
+    if (xcg) {
+        int saved_errno = errno;
+        session_destroy (xcg->session);
+        free (xcg);
+        errno = saved_errno;
+    }
+}
+
+bool exchange_has_error (struct exchange *xcg)
+{
+    return xcg->session->has_error ? true : false;
+}
+
+json_t *exchange_get_dict (struct exchange *xcg)
+{
+    return xcg->session->dict;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/shell/plugins/exchange.h
+++ b/src/shell/plugins/exchange.h
@@ -1,0 +1,38 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_EXCHANGE_H
+#define _PX_EXCHANGE_H
+
+/* Create handle for performing multiple sequential exchanges.
+ * 'k' is the tree fanout (k=0 selects internal default).
+ */
+struct exchange *exchange_create (flux_shell_t *shell, int k);
+void exchange_destroy (struct exchange *xcg);
+
+typedef void (*exchange_f)(struct exchange *xcg, void *arg);
+
+/* Perform one exchange across all shell ranks.
+ * 'dict' is the input from this  shell.  Once the the result of the exchange
+ * is availbale, 'cb' is invoked.
+ */
+int exchange (struct exchange *xcg, json_t *dict, exchange_f cb, void *arg);
+
+/* Accessors may be called only from exchange_f callback.
+ * exchange_get_dict() returns a json object that is invalidated when
+ * the callback returns.
+ */
+bool exchange_has_error (struct exchange *xcg);
+json_t *exchange_get_dict (struct exchange *xcg);
+
+#endif // _PX_EXCHANGE_H
+
+// vi: ts=4 sw=4 expandtab
+

--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -1,0 +1,207 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* fence.c - handle fence_nb callback from openpmix server
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <pmix.h>
+#include <pmix_server.h>
+
+#include "codec.h"
+#include "interthread.h"
+#include "exchange.h"
+
+#include "fence.h"
+
+struct fence {
+    flux_shell_t *shell;
+    struct interthread *it;
+    struct exchange *exchange;
+    int trace_flag;
+};
+
+struct fence_call {
+    pmix_proc_t *procs;
+    size_t nprocs;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_modex_cbfunc_t cbfunc;
+    void *cbdata;
+};
+
+/* This is for the benefit of server callbacks that don't have
+ * a way to be passed a user-supplied opaque pointer.
+ */
+static struct fence *global_fence_ctx;
+
+static void fence_call_destroy (struct fence_call *fxcall)
+{
+    if (fxcall) {
+        int saved_errno = errno;
+        free (fxcall->procs);
+        codec_info_array_destroy (fxcall->info, fxcall->ninfo);
+        free (fxcall);
+        errno = saved_errno;
+    }
+}
+
+static struct fence_call *fence_call_create (void)
+{
+    struct fence_call *fxcall;
+
+    if (!(fxcall = calloc (1, sizeof (*fxcall))))
+        return NULL;
+    return fxcall;
+}
+
+static void exchange_exit_cb (struct exchange *xcg, void *arg)
+{
+    struct fence_call *fxcall = arg;
+    void *data = NULL;
+    size_t ndata = 0;
+    int status = PMIX_ERROR;
+
+    if (exchange_has_error (xcg)) {
+        shell_warn ("pmix exchange failed");
+        goto done;
+    }
+    if (exchange_get_data (xcg, &data, &ndata) < 0) {
+        shell_warn ("error accessing pmix exchanged data");
+        goto done;
+    }
+    shell_trace ("completed pmix exchange");
+    status = PMIX_SUCCESS;
+done:
+    // N.B. pmix calls 'free' on data when fence is complete
+    fxcall->cbfunc (status, data, ndata, fxcall->cbdata, free, data);
+}
+
+static void fence_shell_cb (const flux_msg_t *msg, void *arg)
+{
+    struct fence *fx = arg;
+    json_t *xprocs;
+    json_t *xinfo;
+    json_t *xdata;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    struct fence_call *fxcall;
+
+    if (!(fxcall = fence_call_create ())
+        || flux_msg_unpack (msg,
+                            "{s:o s:o s:o s:o s:o}",
+                            "procs", &xprocs,
+                            "info", &xinfo,
+                            "data", &xdata,
+                            "cbfunc", &xcbfunc,
+                            "cbdata", &xcbdata) < 0
+        || codec_proc_array_decode (xprocs, &fxcall->procs, &fxcall->nprocs) < 0
+        || codec_info_array_decode (xinfo, &fxcall->info, &fxcall->ninfo) < 0
+        || codec_pointer_decode (xcbfunc, (void **)&fxcall->cbfunc) < 0
+        || codec_pointer_decode (xcbdata, &fxcall->cbdata) < 0
+        || fxcall->cbfunc == NULL) {
+        shell_warn ("error unpacking interthread fence_upcall message");
+        fence_call_destroy (fxcall);
+        return;
+    }
+    /* N.B. there is no need to decode 'xdata' as we would need to
+     * re-encode it for the exchange anyway.
+     */
+    if (exchange_enter_base64_string (fx->exchange,
+                                      xdata,
+                                      exchange_exit_cb,
+                                      fxcall) < 0) {
+        shell_warn ("error initiating pmix exchange");
+        fxcall->cbfunc (PMIX_ERROR, NULL, 0, fxcall->cbdata, NULL, NULL);
+        fence_call_destroy (fxcall);
+    }
+    if (fx->trace_flag)
+        shell_trace ("starting pmix exchange");
+}
+
+int fence_server_cb (const pmix_proc_t procs[],
+                     size_t nprocs,
+                     const pmix_info_t info[],
+                     size_t ninfo,
+                     char *data,
+                     size_t ndata,
+                     pmix_modex_cbfunc_t cbfunc,
+                     void *cbdata)
+{
+    struct fence *fx = global_fence_ctx;
+    json_t *xprocs = NULL;
+    json_t *xinfo = NULL;
+    json_t *xdata = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    int rc = PMIX_SUCCESS;
+
+    if (!(xprocs = codec_proc_array_encode (procs, nprocs))
+        || !(xinfo = codec_info_array_encode (info, ninfo))
+        || !(xdata = codec_data_encode (data, ndata))
+        || !(xcbfunc = codec_pointer_encode (cbfunc))
+        || !(xcbdata = codec_pointer_encode (cbdata))
+        || interthread_send_pack (fx->it,
+                                  "fence_upcall",
+                                  "{s:O s:O s:O s:O s:O}",
+                                  "procs", xprocs,
+                                  "info", xinfo,
+                                  "data", xdata,
+                                  "cbfunc", xcbfunc,
+                                  "cbdata", xcbdata) < 0) {
+        fprintf (stderr, "error sending fence_upcall interthread message\n");
+        rc = PMIX_ERROR;
+    }
+    json_decref (xprocs);
+    json_decref (xinfo);
+    json_decref (xdata);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+    return rc;
+}
+
+void fence_destroy (struct fence *fx)
+{
+    if (fx) {
+        int saved_errno = errno;
+        exchange_destroy (fx->exchange);
+        free (fx);
+        errno = saved_errno;
+        global_fence_ctx = NULL;
+    }
+}
+
+struct fence *fence_create (flux_shell_t *shell, struct interthread *it)
+{
+    flux_t *h = flux_shell_get_flux (shell);
+    struct fence *fx;
+
+    if (!(fx = calloc (1, sizeof (*fx))))
+        return NULL;
+    fx->shell = shell;
+    fx->it = it;
+    fx->trace_flag = 1; // stuck on for now
+    if (interthread_register (it, "fence_upcall", fence_shell_cb, fx) < 0)
+        goto error;
+    if (!(fx->exchange = exchange_create (shell, 0)))
+        goto error;
+    global_fence_ctx = fx;
+    return fx;
+error:
+    fence_destroy (fx);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/fence.h
+++ b/src/shell/plugins/fence.h
@@ -1,0 +1,37 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_FENCE_H
+#define _PX_FENCE_H
+
+#include <pmix.h>
+#include <pmix_server.h>
+#include "interthread.h"
+
+/* Create context that allows fence_server_cb() to work.
+ * N.B. ensure pmix thread is not running when create/destroy are called.
+ */
+struct fence *fence_create (flux_shell_t *shell, struct interthread *it);
+void fence_destroy (struct fence *dx);
+
+/* Server fence_nb callback registered with PMIx_server_init().
+ */
+int fence_server_cb (const pmix_proc_t proc[],
+                     size_t nprocs,
+                     const pmix_info_t info[],
+                     size_t ninfo,
+                     char *data,
+                     size_t ndata,
+                     pmix_modex_cbfunc_t cbfunc,
+                     void *cbdata);
+
+#endif // _PX_FENCE_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/interthread.c
+++ b/src/shell/plugins/interthread.c
@@ -1,0 +1,151 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* interthread.c - message channel from pmix server thread -> shell thread
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "interthread.h"
+
+#define MAX_HANDLERS 32
+
+struct handler {
+    char topic[32];
+    interthread_msg_handler_f cb;
+    void *arg;
+};
+
+struct interthread {
+    flux_t *server_h;
+    flux_t *shell_h;
+    flux_watcher_t *w;
+    struct handler handlers[MAX_HANDLERS];
+    int handler_count;
+    bool trace_flag;
+};
+
+int interthread_register (struct interthread *it,
+                          const char *topic,
+                          interthread_msg_handler_f cb,
+                          void *arg)
+{
+    struct handler *handler;
+
+    if (it->handler_count == MAX_HANDLERS) {
+        errno = ENOSPC;
+        return -1;
+    }
+    handler = &it->handlers[it->handler_count++];
+    strncpy (handler->topic, topic, sizeof (handler->topic) - 1);
+    handler->cb = cb;
+    handler->arg = arg;
+    return 0;
+}
+
+int interthread_send_pack (struct interthread *it,
+                           const char *name,
+                           const char *fmt, ...)
+{
+    flux_msg_t *msg = NULL;
+    va_list ap;
+    int rc = 0;
+
+    va_start (ap, fmt);
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST))
+        || flux_msg_set_topic (msg, name) < 0
+        || flux_msg_vpack (msg, fmt, ap) < 0
+        || flux_send (it->server_h, msg, 0) < 0) {
+        rc = -1;
+    }
+    va_end (ap);
+    flux_msg_decref (msg);
+
+    return rc;
+}
+
+static void interthread_recv (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
+{
+    struct interthread *it = arg;
+    flux_msg_t *msg;
+    const char *topic;
+    int i;
+
+    if (!(revents & FLUX_POLLIN)
+        || !(msg = flux_recv (it->shell_h, FLUX_MATCH_ANY, 0)))
+        return;
+    if (flux_msg_get_topic (msg, &topic) < 0) {
+        shell_warn ("interthread receive decode error - message dropped");
+        goto done;
+    }
+    if (it->trace_flag) {
+        const char *payload;
+        int size;
+        if (flux_msg_get_payload (msg, (const void **)&payload, &size) == 0
+            && size > 0)
+            shell_trace ("pmix server %s %.*s", topic, size - 1, payload);
+    }
+    for (i = 0; i < it->handler_count; i++) {
+        if (!strcmp (topic, it->handlers[i].topic))
+            break;
+    }
+    if (i < it->handler_count)
+        it->handlers[i].cb (msg, it->handlers[i].arg);
+    else
+        shell_warn ("unhandled interthread topic %s", topic);
+done:
+    flux_msg_decref (msg);
+}
+
+void interthread_destroy (struct interthread *it)
+{
+    if (it) {
+        int saved_errno = errno;
+        flux_watcher_destroy (it->w);
+        flux_close (it->server_h);
+        flux_close (it->shell_h);
+        free (it);
+        errno = saved_errno;
+    }
+}
+
+struct interthread *interthread_create (flux_shell_t *shell)
+{
+    flux_t *h = flux_shell_get_flux (shell);
+    struct interthread *it;
+
+    if (!(it = calloc (1, sizeof (*it))))
+        return NULL;
+    it->trace_flag = 1; // temporarily force this on
+    if (!(it->shell_h = flux_open ("shmem://pmix-interthread&bind", 0)))
+        goto error;
+    if (!(it->server_h = flux_open ("shmem://pmix-interthread&connect", 0)))
+        goto error;
+    if (!(it->w = flux_handle_watcher_create (flux_get_reactor (h),
+                                              it->shell_h,
+                                              FLUX_POLLIN,
+                                              interthread_recv,
+                                              it)))
+        goto error;
+    flux_watcher_start (it->w);
+    return it;
+error:
+    interthread_destroy (it);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/interthread.h
+++ b/src/shell/plugins/interthread.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_INTERTHREAD_H
+#define _PX_INTERTHREAD_H
+
+#include <flux/shell.h>
+
+struct interthread *interthread_create (flux_shell_t *shell);
+void interthread_destroy (struct interthread *it);
+
+typedef void (*interthread_msg_handler_f)(const flux_msg_t *msg, void *arg);
+
+int interthread_register (struct interthread *it,
+                          const char *topic,
+                          interthread_msg_handler_f cb,
+                          void *arg);
+
+int interthread_send_pack (struct interthread *it,
+                           const char *name,
+                           const char *fmt, ...);
+
+#endif // _PX_INTERTHREAD_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/test/codec.c
+++ b/src/shell/plugins/test/codec.c
@@ -1,0 +1,181 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <pmix_server.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "codec.h"
+
+void check_data (void)
+{
+    json_t *o;
+    char in_buf[64];
+    int in_len;
+    void *out_buf;
+    size_t out_len;
+
+    snprintf (in_buf, sizeof (in_buf), "foobar");
+    in_len = strlen (in_buf) + 1;
+    out_buf = NULL;
+    out_len = -1;
+    ok ((o = codec_data_encode (in_buf, in_len)) != NULL,
+        "codec_data_encode %d bytes works", in_len);
+    ok (codec_data_decode (o, &out_buf, &out_len) == 0,
+        "codec_data_decode works");
+    diag ("out_len = %d", out_len);
+    ok (out_len == in_len
+        && out_buf != NULL
+        && memcmp (in_buf, out_buf, out_len) == 0,
+        "codec_data_decode returned the correct value");
+    free (out_buf);
+}
+
+void check_pointer (void)
+{
+    json_t *o;
+    void *ptr_in;
+    void *ptr_out;
+
+    ptr_in = (void *)~0LL;
+    ptr_out = (void *)0xdeadbeef;
+    ok ((o = codec_pointer_encode (ptr_in)) != NULL,
+        "codec_pointer_encode ~0LL works");
+    ok (codec_pointer_decode (o, &ptr_out) == 0,
+        "codec_pointer_decode works");
+    ok (ptr_in == ptr_out,
+        "codec_pointer_decode returned the correct value");
+
+    ptr_in = 0;
+    ptr_out = (void *)0xdeadbeef;
+    ok ((o = codec_pointer_encode (ptr_in)) != NULL,
+        "codec_pointer_encode 0 works");
+    ok (codec_pointer_decode (o, &ptr_out) == 0,
+        "codec_pointer_decode works");
+    ok (ptr_in == ptr_out,
+        "codec_pointer_decode returned the correct value");
+}
+
+void check_value ()
+{
+    json_t *o;
+    pmix_value_t val;
+    pmix_value_t val2;
+    pmix_proc_t proc;
+    pmix_proc_t *proc2;
+
+    val.type = PMIX_BOOL;
+    val.data.flag = true;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.flag == val2.data.flag,
+        "codec_value_encode/decode works for boolean");
+    json_decref (o);
+
+    val.type = PMIX_BYTE;
+    val.data.byte = 0x42;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.byte == val2.data.byte,
+        "codec_value_encode/decode works for byte");
+
+    val.type = PMIX_STRING;
+    val.data.string = "foo";
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && !strcmp (val.data.string, val2.data.string),
+        "codec_value_encode/decode works for string");
+    codec_value_release (&val2);
+
+    val.type = PMIX_SIZE;
+    val.data.size = 777;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.size == val2.data.size,
+        "codec_value_encode/decode works for size");
+
+    val.type = PMIX_PID;
+    val.data.pid = 69;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.pid == val2.data.pid,
+        "codec_value_encode/decode works for pid");
+
+    // TODO INT
+    // TODO INT8
+    // TODO INT16
+    // TODO INT32
+    // TODO INT64
+
+    // TODO UINT
+    // TODO UINT8
+    // TODO UINT64
+
+    val.type = PMIX_UINT16;
+    val.data.uint16 = 0x9999;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.uint16 == val2.data.uint16,
+        "codec_value_encode/decode works for uint16");
+
+    val.type = PMIX_UINT32;
+    val.data.uint32 = 0xeeeeffff;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.uint32 == val2.data.uint32,
+        "codec_value_encode/decode works for uint32");
+
+    val.type = PMIX_PROC_RANK;
+    val.data.rank= 1;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.rank == val2.data.rank,
+        "codec_value_encode/decode works for rank");
+
+    // TODO FLOAT
+    // TODO DOUBLE
+    // TODO TIMEVAL
+    // TODO TIME
+    // TODO STATUS
+
+    proc.rank = 3;
+    snprintf (proc.nspace, sizeof (proc.nspace), "xyz");
+
+    val.type = PMIX_PROC;
+    val.data.proc = &proc;
+    o = codec_value_encode (&val);
+    ok (codec_value_decode (o, &val2) == 0
+        && val.type == val2.type
+        && val.data.proc->rank == val2.data.proc->rank
+        && !strcmp (val.data.proc->nspace, val2.data.proc->nspace),
+        "codec_value_encode/decode works for proc");
+    codec_value_release (&val2);
+}
+
+int main (int argc, char **argv)
+{
+    plan (NO_PLAN);
+
+    check_pointer ();
+    check_data ();
+    check_value ();
+
+    // TODO pmix_info_t
+    // TODO pmix_proc_t
+    // TODO array of pmix_proc_t
+    // TODO array of pmix_info_t
+
+    done_testing ();
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t0003-bizcard.t
+++ b/t/t0003-bizcard.t
@@ -27,11 +27,37 @@ test_expect_success '1n2p barrier works' '
 		${BARRIER}
 '
 
+test_expect_success '2n2p barrier works' '
+	run_timeout 30 flux mini run -N2 -n2 \
+		-overbose=2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER}
+'
+
+test_expect_success '2n4p barrier works' '
+	run_timeout 30 flux mini run -N2 -n4 \
+		-overbose=2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER}
+'
+
 test_expect_success '1n2p bizcard exchange works' '
        run_timeout 30 flux mini run -N1 -n2 \
                -ouserrc=$(pwd)/rc.lua \
                ${BIZCARD} 1
 '
 
+test_expect_success '2n2p bizcard exchange works' '
+       run_timeout 30 flux mini run -N2 -n2 \
+	       -overbose=2 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${BIZCARD} 1
+'
+
+test_expect_success '2n4p bizcard exchange works' '
+       run_timeout 30 flux mini run -N2 -n4 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${BIZCARD} 1
+'
 
 test_done


### PR DESCRIPTION
This implements the openpmix fence callback using a collective operation similar to the one used in our pmi-1 implementation.  In fact, since that implementation was already abstracted, this pulls it in and modifies it to be usable in an external project, and to fit the openpmix fence server-side data model.  (We could consider implementing it as a generic shell service at some point but I think not today).

This also introduces a shmem message queue and codec to synchronize the pmix fence callback in the server thread with the shell's reactor thread.  The callbacks are converted into interthread messages.  The message queue was implemented with back to back `shmem://` flux_t handles, so flux's "handle watcher" and message send/recv functions could be used.

A couple of test cases demo both a barrier (fence with no data) and a business card exchange across multiple shells.