### PR TITLE
parse fence upcall parameters

### DIFF
--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -89,6 +89,34 @@ done:
     fxcall->cbfunc (status, data, ndata, fxcall->cbdata, free, data);
 }
 
+/* Parse info[] attributes from the fence callback.
+ * Return PMIX_SUCCESS or an error status.
+ */
+static int parse_fence_attr (struct fence_call *fxcall, pmix_info_t *info)
+{
+    int rc = PMIX_SUCCESS;
+    int required = (info->flags & PMIX_INFO_REQD);
+
+    if (!strcmp (info->key, "pmix.collect")) {
+        /* ignore this attribute - we always collect data posted by
+         * the participants.  However if it is set to false, log it.
+         */
+        if (!info->value.data.flag)
+            shell_debug ("ignoring fence attr %s=%s",
+                         info->key,
+                         info->value.data.flag ? "true" : "false");
+        goto done;
+    }
+
+    shell_warn ("unknown %s fence attr: %s",
+                required ? "required" : "optional",
+                info->key);
+    if (required)
+        rc = PMIX_ERR_BAD_PARAM;
+done:
+    return rc;
+}
+
 static void fence_shell_cb (const flux_msg_t *msg, void *arg)
 {
     struct fence *fx = arg;
@@ -98,13 +126,14 @@ static void fence_shell_cb (const flux_msg_t *msg, void *arg)
     json_t *xcbfunc;
     json_t *xcbdata;
     struct fence_call *fxcall;
+    int rc;
 
     if (!(fxcall = fence_call_create ())
         || flux_msg_unpack (msg,
                             "{s:o s:o s:o s:o s:o}",
                             "procs", &xprocs,
                             "info", &xinfo,
-                            "data", &xdata,
+                            "data", &xdata, // not further decoded here
                             "cbfunc", &xcbfunc,
                             "cbdata", &xcbdata) < 0
         || codec_proc_array_decode (xprocs, &fxcall->procs, &fxcall->nprocs) < 0
@@ -116,19 +145,24 @@ static void fence_shell_cb (const flux_msg_t *msg, void *arg)
         fence_call_destroy (fxcall);
         return;
     }
-    /* N.B. there is no need to decode 'xdata' as we would need to
-     * re-encode it for the exchange anyway.
-     */
+    for (int i = 0; i < fxcall->ninfo; i++) {
+        if ((rc = parse_fence_attr (fxcall, &fxcall->info[i])) != PMIX_SUCCESS)
+            goto error;
+    }
     if (exchange_enter_base64_string (fx->exchange,
                                       xdata,
                                       exchange_exit_cb,
                                       fxcall) < 0) {
         shell_warn ("error initiating pmix exchange");
-        fxcall->cbfunc (PMIX_ERROR, NULL, 0, fxcall->cbdata, NULL, NULL);
-        fence_call_destroy (fxcall);
+        rc = PMIX_ERROR;
+        goto error;
     }
     if (fx->trace_flag)
         shell_trace ("starting pmix exchange");
+    return;
+error:
+    fxcall->cbfunc (rc, NULL, 0, fxcall->cbdata, NULL, NULL);
+    fence_call_destroy (fxcall);
 }
 
 int fence_server_cb (const pmix_proc_t procs[],

--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -145,6 +145,11 @@ static void fence_shell_cb (const flux_msg_t *msg, void *arg)
         fence_call_destroy (fxcall);
         return;
     }
+    if (fxcall->nprocs > 1 || fxcall->procs[0].rank != PMIX_RANK_WILDCARD) {
+        shell_warn ("fence over proc subset is not supported by flux");
+        rc = PMIX_ERR_NOT_SUPPORTED;
+        goto error;
+    }
     for (int i = 0; i < fxcall->ninfo; i++) {
         if ((rc = parse_fence_attr (fxcall, &fxcall->info[i])) != PMIX_SUCCESS)
             goto error;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -26,7 +26,8 @@ TESTSCRIPTS = \
 	t0000-sharness.t \
 	t0001-ompi-sanity.t \
 	t0002-basic.t \
-	t0003-bizcard.t
+	t0003-barrier.t \
+	t0004-bizcard.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -29,8 +29,15 @@ test_ldadd = \
 	$(builddir)/libtestutil.la
 
 barrier_SOURCES = barrier.c
-barrier_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
-barrier_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
+barrier_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(PMIX_CFLAGS) \
+	$(FLUX_OPTPARSE_CFLAGS) \
+	$(FLUX_IDSET_CFLAGS)
+barrier_LDADD = $(test_ldadd) \
+	$(PMIX_LIBS) \
+	$(FLUX_OPTPARSE_LIBS) \
+	$(FLUX_IDSET_LIBS)
 
 bizcard_SOURCES = bizcard.c
 bizcard_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -29,8 +29,8 @@ test_ldadd = \
 	$(builddir)/libtestutil.la
 
 barrier_SOURCES = barrier.c
-barrier_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)
-barrier_LDADD = $(test_ldadd) $(PMIX_LIBS)
+barrier_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
+barrier_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
 
 bizcard_SOURCES = bizcard.c
 bizcard_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)

--- a/t/t0001-ompi-sanity.t
+++ b/t/t0001-ompi-sanity.t
@@ -28,6 +28,12 @@ test_expect_success 'prterun barrier' '
 	${PRTERUN} --n 8 ${BARRIER}
 '
 
+# XXX This occasionally hangs.
+test_expect_success XFAIL 'prterun barrier works with procs subset' '
+	${PRTERUN} --n 8 ${BARRIER} --procs=0-1
+'
+
+
 test_expect_success 'prterun bizcard' '
 	${PRTERUN} --n 8 ${BIZCARD} 1
 '

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -1,13 +1,12 @@
 #!/bin/sh
 
-test_description='Exercise the business card exchange use case.'
+test_description='Exercise empty fence (barrier).'
 
 PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
 
 . `dirname $0`/sharness.sh
 
 BARRIER=${FLUX_BUILD_DIR}/t/src/barrier
-BIZCARD=${FLUX_BUILD_DIR}/t/src/bizcard
 
 test_under_flux 2
 
@@ -39,25 +38,6 @@ test_expect_success '2n4p barrier works' '
 		-overbose=2 \
 		-ouserrc=$(pwd)/rc.lua \
 		${BARRIER}
-'
-
-test_expect_success '1n2p bizcard exchange works' '
-       run_timeout 30 flux mini run -N1 -n2 \
-               -ouserrc=$(pwd)/rc.lua \
-               ${BIZCARD} 1
-'
-
-test_expect_success '2n2p bizcard exchange works' '
-       run_timeout 30 flux mini run -N2 -n2 \
-	       -overbose=2 \
-               -ouserrc=$(pwd)/rc.lua \
-               ${BIZCARD} 1
-'
-
-test_expect_success '2n4p bizcard exchange works' '
-       run_timeout 30 flux mini run -N2 -n4 \
-               -ouserrc=$(pwd)/rc.lua \
-               ${BIZCARD} 1
 '
 
 test_done

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -20,11 +20,41 @@ test_expect_success 'create rc.lua script' "
 	EOT
 "
 
+# Single-shell barriers do not trigger fence server upcall,
+# so the 1n2p tests are just checking openpmix behavior
+
 test_expect_success '1n2p barrier works' '
 	run_timeout 30 flux mini run -N1 -n2 \
 		-ouserrc=$(pwd)/rc.lua \
 		${BARRIER}
 '
+
+test_expect_success '1n2p barrier tolerates pmix.timeout=2' '
+	run_timeout 30 flux mini run -N1 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --timeout=2s
+'
+
+test_expect_success '1n2p barrier tolerates pmix.collect=false' '
+	run_timeout 30 flux mini run -N1 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --collect-data=false
+'
+
+# This works but it shouldn't per spec v5 sec 3.2.10
+test_expect_success XFAIL '1n2p barrier rejects required unknown option' '
+	test_must_fail run_timeout 30 flux mini run -N1 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --unknown=+42
+'
+
+test_expect_success '1n2p barrier tolerates pmix.collect.gen=false' '
+	run_timeout 30 flux mini run -N1 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --collect-job-info=false
+'
+
+# Multi-shell barrier
 
 test_expect_success '2n2p barrier works' '
 	run_timeout 30 flux mini run -N2 -n2 \
@@ -32,6 +62,42 @@ test_expect_success '2n2p barrier works' '
 		-ouserrc=$(pwd)/rc.lua \
 		${BARRIER}
 '
+
+test_expect_success '2n2p barrier tolerates optional pmix.timeout=2' '
+	run_timeout 30 flux mini run -N2 -n2 \
+		-overbose=2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --timeout=2s
+'
+
+test_expect_success '2n2p barrier tolerates optional pmix.collect=false' '
+	run_timeout 30 flux mini run -N2 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --collect-data=false
+'
+
+test_expect_success '2n2p barrier tolerates optional pmix.collect.gen=false' '
+	run_timeout 30 flux mini run -N2 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --collect-job-info=false
+'
+
+# This works but it shouldn't per spec v5 sec 3.2.10
+# N.B. PMIX_INFO_REQD flag is clear when it reaches our callback
+test_expect_success XFAIL '2n2p barrier rejects required pmix.collect.gen=false' '
+	test_must_fail run_timeout 30 flux mini run -N2 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		-overbose=2 \
+		${BARRIER} --collect-job-info=+false
+'
+
+test_expect_success '2n2p barrier tolerates optional unknown attr' '
+	run_timeout 30 flux mini run -N2 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --unknown=42
+'
+
+# Try a larger size for fun
 
 test_expect_success '2n4p barrier works' '
 	run_timeout 30 flux mini run -N2 -n4 \

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -54,6 +54,12 @@ test_expect_success '1n2p barrier tolerates pmix.collect.gen=false' '
 		${BARRIER} --collect-job-info=false
 '
 
+test_expect_success '1n2p barrier with procs subset works' '
+	run_timeout 30 flux mini run -N1 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER} --procs=0
+'
+
 # Multi-shell barrier
 
 test_expect_success '2n2p barrier works' '
@@ -95,6 +101,23 @@ test_expect_success '2n2p barrier tolerates optional unknown attr' '
 	run_timeout 30 flux mini run -N2 -n2 \
 		-ouserrc=$(pwd)/rc.lua \
 		${BARRIER} --unknown=42
+'
+
+# N.B. This hangs in openpmix and we never get our fence upcall
+test_expect_success XFAIL '2n2p barrier with procs subset fails' '
+	test_must_fail run_timeout 30 flux mini run -N2 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		-overbose=2 \
+		${BARRIER} --procs=1
+'
+
+# This exercises the "subset" code path in our upcall, but only
+# because it assumes non-wildcard proc entry is a subset
+test_expect_success '2n2p barrier with procs explictly set fails' '
+	test_must_fail run_timeout 30 flux mini run -N2 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		-overbose=2 \
+		${BARRIER} --procs=0-1
 '
 
 # Try a larger size for fun

--- a/t/t0004-bizcard.t
+++ b/t/t0004-bizcard.t
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+test_description='Exercise the business card exchange use case.'
+
+PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
+
+. `dirname $0`/sharness.sh
+
+BIZCARD=${FLUX_BUILD_DIR}/t/src/bizcard
+
+test_under_flux 2
+
+test_expect_success 'print pmix library version' '
+	${VERSION}
+'
+
+test_expect_success 'create rc.lua script' "
+	cat >rc.lua <<-EOT
+	plugin.load (\"$PLUGINPATH/pmix.so\")
+	EOT
+"
+
+test_expect_success '1n2p bizcard exchange works' '
+       run_timeout 30 flux mini run -N1 -n2 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${BIZCARD} 1
+'
+
+test_expect_success '2n2p bizcard exchange works' '
+       run_timeout 30 flux mini run -N2 -n2 \
+	       -overbose=2 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${BIZCARD} 1
+'
+
+test_expect_success '2n4p bizcard exchange works' '
+       run_timeout 30 flux mini run -N2 -n4 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${BIZCARD} 1
+'
+
+test_done


### PR DESCRIPTION
Problem: the` procs[]` and `info[]` arguments to the fence upcall are currently ignored.

`procs` is apparently for specifying a subset of ranks to synchronize over, which we  don't support.  If `PMIx_Fence()` is called with this set to NULL, then we get one procs entry containing a wildcard rank.  Accept this, and fail all others.

Note: in writing tests, I noticed that specifying a subset of ranks seems to hang in openpmix and we never get our upcall.  I'm not sure why this is.  However I was able to cover this code path in the server by specifying a full set of ranks rather than the wildcard, something which is probably never done.

`info` is how options are passed to the upcall.  The primary logic that needs to be implemented is to fail the fence call if the user marks any unhandled attributes as required.  Add code for this.

Note: in writing tests, I noticed that this flag never reaches our upcall.  It seems to be cleared in openpmix.  Furthermore, when openpmix is entirely handling the fence (no upcall), it tolerates unknown, required options, contrary to the spec, at least by my read.

So that was unsatisfying, and possibly I am misunderstanding something.  However, I still would like this to go in for now - we can fix it later if it causes a problem.