### PR TITLE
fix incorrect setting of pmix.lpeers

### DIFF
--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -52,6 +52,22 @@ static void px_destroy (struct px *px)
     }
 }
 
+static int set_lpeers (struct infovec *iv,
+                       const char *key,
+                       flux_shell_t *shell)
+{
+    char *s;
+
+    if (!(s = maps_lpeers_create (shell)))
+        return -1;
+    shell_debug ("local_peers = %s", s);
+    if (infovec_set_str_new (iv, key, s) < 0) { // steals s
+        free (s);
+        return -1;
+    }
+    return 0;
+}
+
 static int set_node_map (struct infovec *iv,
                          const char *key,
                          flux_shell_t *shell)
@@ -162,6 +178,7 @@ static int px_init (flux_plugin_t *p,
     }
 
     if (!(iv = infovec_create ())
+        || set_lpeers (iv, PMIX_LOCAL_PEERS, shell) < 0
         || set_node_map (iv, PMIX_NODE_MAP, shell) < 0
         || set_proc_map (iv, PMIX_PROC_MAP, shell) < 0
         || infovec_set_str (iv, PMIX_NSDIR, px->job_tmpdir) < 0

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -62,6 +62,7 @@ static int set_node_map (struct infovec *iv,
 
     if (!(raw = maps_node_create (shell)))
         return -1;
+    shell_debug ("node_map = %s", raw);
     if ((rc = PMIx_generate_regex (raw, &cooked) != PMIX_SUCCESS)) {
         free (raw);
         shell_warn ("PMIx_generate_regex: %s", PMIx_Error_string (rc));
@@ -86,6 +87,7 @@ static int set_proc_map (struct infovec *iv,
 
     if (!(raw = maps_proc_create (shell)))
         return -1;
+    shell_debug ("proc_map = %s", raw);
     if ((rc = PMIx_generate_ppn (raw, &cooked) != PMIX_SUCCESS)) {
         free (raw);
         shell_warn ("PMIx_generate_ppn: %s", PMIx_Error_string (rc));

--- a/src/shell/plugins/maps.h
+++ b/src/shell/plugins/maps.h
@@ -13,6 +13,7 @@
 
 #include <flux/shell.h>
 
+char *maps_lpeers_create (flux_shell_t *shell);
 char *maps_proc_create (flux_shell_t *shell);
 char *maps_node_create (flux_shell_t *shell);
 

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -110,8 +110,7 @@ test_expect_success '2n4p pmix.hname is set' '
 		${GETKEY} --label-io pmix.hname
 '
 
-# This does not produce the expected results and needs investigation.
-test_expect_success XFAIL '2n4p pmix.lpeers is set correctly' '
+test_expect_success '2n4p pmix.lpeers is set correctly' '
 	cat >pmix.lpeers.exp <<-EOT &&
 	0: 0,1
 	1: 0,1


### PR DESCRIPTION
As described in #7, `pmix.lpeers` is set wrong when there are multiple shells on the same node.  I have not tested multiple shells, each on a unique node (probably OK).

The fix requires two components:
- ensure the hostnames in the `pmix.nmap` (the node map) are unique by appending the shell rank, but only if duplicates are detected
- set the correct value of `pmix.lpeers` in the server nspace

Neither of these fixes it independently, we need both.