### PR TITLE
add abort handler

### DIFF
--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -22,7 +22,9 @@ pmix_la_SOURCES = \
 	exchange.h \
 	exchange.c \
 	fence.h \
-	fence.c
+	fence.c \
+	abort.h \
+	abort.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \

--- a/src/shell/plugins/abort.c
+++ b/src/shell/plugins/abort.c
@@ -1,0 +1,163 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* abort.c - handle abort callback from openpmix server
+ *
+ * User calls PMIx_Abort (status, msg, NULL, 0)
+ *
+ * This is translated into shell_die() using 'status' as the exit code.
+ * shell_die() raises a fatal exception on the job before calling exit(3).
+ * (Probably the czmq atexit handler for the interthread sockets will complain.)
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <pmix.h>
+#include <pmix_server.h>
+
+#include "codec.h"
+#include "interthread.h"
+
+#include "abort.h"
+
+struct abort {
+    flux_shell_t *shell;
+    struct interthread *it;
+    int trace_flag;
+};
+
+/* This is for the benefit of server callbacks that don't have
+ * a way to be passed a user-supplied opaque pointer.
+ */
+static struct abort *global_abort_ctx;
+
+static void abort_shell_cb (const flux_msg_t *msg, void *arg)
+{
+    struct abort *abort = arg;
+
+    json_t *xproc;
+    json_t *xserver_object;
+    json_t *xprocs;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    pmix_proc_t proc;
+    void *server_object;
+    int status;
+    pmix_proc_t *procs;
+    size_t nprocs;
+    const char *message;
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:o s:i s:s s:o s:o s:o}",
+                         "proc", &xproc,
+                         "server_object", &xserver_object,
+                         "status", &status,
+                         "msg", &message,
+                         "procs", &xprocs,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0
+        || codec_proc_decode (xproc, &proc) < 0
+        || codec_pointer_decode (xserver_object, &server_object) < 0
+        || codec_proc_array_decode (xprocs, &procs, &nprocs) < 0
+        || codec_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || codec_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error unpacking interthread abort_upcall message");
+        return;
+    }
+    if (cbfunc)
+        cbfunc (PMIX_SUCCESS, cbdata);
+    shell_die (status,
+               "%s.%d called PMIx_Abort: %s",
+               proc.nspace,
+               proc.rank,
+               message);
+    free (procs);
+}
+
+int abort_server_cb (const pmix_proc_t *proc,
+                     void *server_object,
+                     int status,
+                     const char msg[],
+                     pmix_proc_t procs[],
+                     size_t nprocs,
+                     pmix_op_cbfunc_t cbfunc,
+                     void *cbdata)
+{
+    struct abort *abort = global_abort_ctx;
+    json_t *xproc = NULL;
+    json_t *xserver_object = NULL;
+    json_t *xprocs = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = PMIX_SUCCESS;
+    int rc = PMIX_SUCCESS;
+
+    if (!(xproc = codec_proc_encode (proc))
+        || !(xserver_object = codec_pointer_encode (server_object))
+        || !(xprocs = codec_proc_array_encode (procs, nprocs))
+        || !(xcbfunc = codec_pointer_encode (cbfunc))
+        || !(xcbdata = codec_pointer_encode (cbdata))
+        || interthread_send_pack (abort->it,
+                                  "abort_upcall",
+                                  "{s:O s:O s:i s:s s:O s:O s:O}",
+                                  "proc", xproc,
+                                  "server_object", xserver_object,
+                                  "status", status,
+                                  "msg", msg ? msg : "(no message)",
+                                  "procs", xprocs,
+                                  "cbfunc", xcbfunc,
+                                  "cbdata", xcbdata) < 0) {
+        fprintf (stderr, "error sending abort_upcall interthread message\n");
+        rc = PMIX_ERROR;
+    }
+done:
+    json_decref (xproc);
+    json_decref (xserver_object);
+    json_decref (xprocs);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+
+    return rc;
+}
+
+void abort_destroy (struct abort *abort)
+{
+    if (abort) {
+        int saved_errno = errno;
+        free (abort);
+        errno = saved_errno;
+        global_abort_ctx = NULL;
+    }
+}
+
+struct abort *abort_create (flux_shell_t *shell, struct interthread *it)
+{
+    struct abort *abort;
+
+    if (!(abort = calloc (1, sizeof (*abort))))
+        return NULL;
+    abort->shell = shell;
+    abort->it = it;
+    abort->trace_flag = 1; // stuck on for now
+    if (interthread_register (it, "abort_upcall", abort_shell_cb, abort) < 0)
+        goto error;
+    global_abort_ctx = abort;
+    return abort;
+error:
+    abort_destroy (abort);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/abort.h
+++ b/src/shell/plugins/abort.h
@@ -1,0 +1,37 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_ABORT_H
+#define _PX_ABORT_H
+
+#include <pmix.h>
+#include <pmix_server.h>
+#include "interthread.h"
+
+/* Create context that allows abort_server_cb() to work.
+ * N.B. ensure pmix thread is not running when create/destroy are called.
+ */
+struct abort *abort_create (flux_shell_t *shell, struct interthread *it);
+void abort_destroy (struct abort *abort);
+
+/* Server abort callback registered with PMIx_server_init().
+ */
+int abort_server_cb (const pmix_proc_t *proc,
+                     void *server_object,
+                     int status,
+                     const char msg[],
+                     pmix_proc_t procs[],
+                     size_t nprocs,
+                     pmix_op_cbfunc_t cbfunc,
+                     void *cbdata);
+
+#endif // _PX_ABORT_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -224,7 +224,6 @@ void fence_destroy (struct fence *fx)
 
 struct fence *fence_create (flux_shell_t *shell, struct interthread *it)
 {
-    flux_t *h = flux_shell_get_flux (shell);
     struct fence *fx;
 
     if (!(fx = calloc (1, sizeof (*fx))))

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -43,7 +43,7 @@ static void px_destroy (struct px *px)
     if (px) {
         int rc;
         int saved_errno = errno;
-        if ((rc = PMIx_server_finalize ()))
+        if ((rc = PMIx_server_finalize ()) != PMIX_SUCCESS)
             shell_warn ("PMIx_server_finalize: %s", PMIx_Error_string (rc));
         fence_destroy (px->fence);
         interthread_destroy (px->it);

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -161,6 +161,12 @@ static int px_init (flux_plugin_t *p,
     if (!(px->job_tmpdir = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR")))
         return -1;
 
+    if (px->shell_rank == 0) {
+        const char *s = PMIx_Get_version ();
+        const char *cp = strchr (s, ',');
+        int len = cp ? cp - s : strlen (s);
+        shell_debug ("server outsourced to %.*s", len, s);
+    }
     if (!(px->it = interthread_create (shell)))
         return -1;
     if (!(px->fence = fence_create (shell, px->it)))

--- a/src/shell/plugins/test/codec.c
+++ b/src/shell/plugins/test/codec.c
@@ -161,6 +161,24 @@ void check_value ()
     codec_value_release (&val2);
 }
 
+void check_proc_array (void)
+{
+    json_t *o;
+    pmix_proc_t *procs;
+    size_t nprocs;
+
+    /* null array in and out */
+    o = codec_proc_array_encode (NULL, 0);
+    ok (o != NULL,
+        "codec_proc_array_encode procs=NULL nprocs=0 works");
+
+    nprocs = 42;
+    ok (codec_proc_array_decode (o, &procs, &nprocs) == 0,
+        "codec_proc_array_decode works");
+    ok (nprocs == 0,
+        "nprocs is set to 0");
+}
+
 int main (int argc, char **argv)
 {
     plan (NO_PLAN);
@@ -171,7 +189,9 @@ int main (int argc, char **argv)
 
     // TODO pmix_info_t
     // TODO pmix_proc_t
-    // TODO array of pmix_proc_t
+
+    check_proc_array ();
+
     // TODO array of pmix_info_t
 
     done_testing ();

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -27,7 +27,8 @@ TESTSCRIPTS = \
 	t0001-ompi-sanity.t \
 	t0002-basic.t \
 	t0003-barrier.t \
-	t0004-bizcard.t
+	t0004-bizcard.t \
+	t0005-abort.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -13,6 +13,7 @@ check_PROGRAMS = \
 	bizcard \
 	version \
 	getkey \
+	abort \
 	mpi_hello \
 	mpi_version \
 	mpi_abort
@@ -50,6 +51,10 @@ version_LDADD = $(test_ldadd) $(PMIX_LIBS)
 getkey_SOURCES = getkey.c
 getkey_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
 getkey_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
+
+abort_SOURCES = abort.c
+abort_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
+abort_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
 
 mpi_hello_SOURCES = mpi_hello.c
 mpi_hello_CPPFLAGS = $(AM_CPPFLAGS) $(OMPI_CFLAGS)

--- a/t/src/abort.c
+++ b/t/src/abort.c
@@ -1,0 +1,102 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+/* abort.c - call PMIx_Abort()
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pmix.h>
+#include <stdio.h>
+#include <flux/optparse.h>
+
+#include "log.h"
+
+const char *opt_usage = "[OPTIONS]";
+
+static struct optparse_option opts[] = {
+    { .name = "message", .has_arg = 1, .arginfo = "TEXT",
+      .usage = "set PMIx_Abort message (default=none)",
+    },
+    { .name = "status", .has_arg = 1, .arginfo = "INT",
+      .usage = "set PMIx_Abort status (default=1)",
+    },
+    { .name = "rank", .has_arg = 1, .arginfo = "INT",
+      .usage = "select rank on which to call PMIx_Abort (default=0)",
+    },
+    OPTPARSE_TABLE_END,
+};
+
+int main (int argc, char **argv)
+{
+    optparse_t *p;
+    int optindex;
+    pmix_proc_t self;
+    int abort_rank;
+    int abort_status;
+    const char *abort_message;
+    int rc;
+
+    /* Parse args
+     */
+    if (!(p = optparse_create ("abort"))
+        || optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS
+        || optparse_set (p, OPTPARSE_USAGE, opt_usage) != OPTPARSE_SUCCESS)
+        log_msg_exit ("error setting up option parsing");
+    if ((optindex = optparse_parse_args (p, argc, argv)) < 0)
+        return 1;
+    if (optindex != argc) {
+        optparse_print_usage (p);
+        return 1;
+    }
+    abort_rank = optparse_get_int (p, "rank", 0);
+    abort_message = optparse_get_str (p, "message", NULL);
+    abort_status = optparse_get_int (p, "status", 1);
+
+    /* Initialize and set log prefix to nspace.rank
+     */
+    char name[512];
+    if ((rc = PMIx_Init (&self, NULL, 0)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Init: %s", PMIx_Error_string (rc));
+    snprintf (name, sizeof (name), "%s.%d", self.nspace, self.rank);
+    log_init (name);
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Init.");
+
+    /* Get the size and print it so we know the test wired up.
+     */
+    pmix_proc_t proc;
+    pmix_value_t *valp;
+    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
+    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    proc.rank = PMIX_RANK_WILDCARD;
+    if ((rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &valp)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Get %s: %s", PMIX_JOB_SIZE, PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("there are %d tasks",
+                 valp->type == PMIX_UINT32 ? valp->data.uint32 : -1);
+    PMIX_VALUE_RELEASE (valp);
+
+    if (self.rank == abort_rank)
+        PMIx_Abort (abort_status, abort_message, NULL, 0);
+
+    /* Finalize
+     */
+    if ((rc = PMIx_Finalize (NULL, 0)))
+        log_msg_exit ("PMIx_Finalize: %s", PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Finalize.");
+
+    optparse_destroy (p);
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t0005-abort.t
+++ b/t/t0005-abort.t
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+test_description='Exercise handler for PMIx_Abort'
+
+PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
+
+. `dirname $0`/sharness.sh
+
+ABORT=${FLUX_BUILD_DIR}/t/src/abort
+
+test_under_flux 2
+
+test_expect_success 'create rc.lua script' "
+	cat >rc.lua <<-EOT
+	plugin.load (\"$PLUGINPATH/pmix.so\")
+	EOT
+"
+
+test_expect_success '1n1p abort on rank 0 works and exit code propagates' '
+       test_expect_code 42 flux mini run \
+               -ouserrc=$(pwd)/rc.lua \
+               ${ABORT} --status=42 --rank=0 --message=abort-test 2>abort.err
+'
+
+test_expect_success 'stderr contains abort message' '
+	grep abort-test abort.err
+'
+
+test_expect_success '1n2p abort on rank 1 works and exit code propagates' '
+       test_expect_code 42 flux mini run -n2 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${ABORT} --status=42 --rank=1 --message=abort-test
+'
+
+test_expect_success '2n2p abort on rank 1 works and exit code propagates' '
+       test_expect_code 42 flux mini run -N2 -n2 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${ABORT} --status=42 --rank=1 --message=abort-test
+'
+
+test_expect_success '1n1p abort on rank 0 works with no message' '
+       test_expect_code 42 flux mini run \
+               -ouserrc=$(pwd)/rc.lua \
+               ${ABORT} --status=42 --rank=0
+'
+
+test_done


### PR DESCRIPTION
This adds another pmix server callback for handling `PMIx_Abort()`.  All we do is call `shell_die()`, like the the builtin pmi plugin's abort handler.  That unfortunately gets us in trouble with the czmq atexit handler, so the output is a bit noisy.  Maybe OK for now?
```
ok 4 - 1n2p abort on rank 1 works and exit code propagates

expecting success: 
       test_expect_code 42 flux mini run -N2 -n2 \
               -ouserrc=$(pwd)/rc.lua \
               ${ABORT} --status=42 --rank=1 --message=abort-test

0.072s: flux-shell[1]: FATAL: fXmz6JB.1 called PMIx_Abort: abort-test
0.073s: job.exception type=exec severity=0 fXmz6JB.1 called PMIx_Abort: abort-test
0.072s: flux-shell[1]: stderr: flux-shell: FATAL: fXmz6JB.1 called PMIx_Abort: abort-test
0.274s: flux-shell[1]: stdout: E: 21-09-23 23:15:30 [320132]dangling 'PAIR' socket created at shmem.c:196
0.274s: flux-shell[1]: stdout: E: 21-09-23 23:15:30 [320132]dangling 'PAIR' socket created at shmem.c:196
fXmz6JB.0: completed PMIx_Init.
fXmz6JB.0: there are 2 tasks
fXmz6JB.0: completed PMIx_Finalize.
flux-job: task(s) exited with exit code 42
```