### PR TITLE
add error notification callback

### DIFF
--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -24,7 +24,9 @@ pmix_la_SOURCES = \
 	fence.h \
 	fence.c \
 	abort.h \
-	abort.c
+	abort.c \
+	notify.h \
+	notify.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \

--- a/src/shell/plugins/notify.c
+++ b/src/shell/plugins/notify.c
@@ -1,0 +1,190 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* notify.c - register and handle error notification callback
+ *
+ * Any notifications (from openpmix internals or from users) are
+ * logged to the shell's stderr via shell_warn().  The spec has
+ * much bigger plans for event notifications, but the goal here
+ * is just to capture any useful errors from openpmix internals.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <pmix.h>
+#include <pmix_server.h>
+
+#include "codec.h"
+#include "interthread.h"
+
+#include "notify.h"
+
+struct notify {
+    flux_shell_t *shell;
+    struct interthread *it;
+    int id;
+};
+
+/* This is for the benefit of server callbacks that don't have
+ * a way to be passed a user-supplied opaque pointer.
+ */
+static struct notify *global_notify_ctx;
+
+static void notify_shell_cb (const flux_msg_t *msg, void *arg)
+{
+    int id;
+    int status;
+    json_t *xsource;
+    json_t *xinfo;
+    json_t *xresults;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    pmix_proc_t source;
+    pmix_info_t *info = NULL;
+    size_t ninfo = 0;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_event_notification_cbfunc_fn_t cbfunc;
+    void *cbdata;
+    int i;
+    const char *message = NULL;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:i s:o s:o s:o s:o s:o}",
+                         "id", &id,
+                         "status", &status,
+                         "source", &xsource,
+                         "info", &xinfo,
+                         "results", &xresults,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0
+        || codec_proc_decode (xsource, &source) < 0
+        || codec_info_array_decode (xinfo, &info, &ninfo) < 0
+        || codec_info_array_decode (xresults, &results, &nresults) < 0
+        || codec_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || codec_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error unpacking interthread abort_upcall message");
+        goto done;
+    }
+    for (i = 0; i < ninfo; i++) {
+        if (!strcmp (info[i].key, PMIX_EVENT_TEXT_MESSAGE)) {
+            if (info[i].value.type == PMIX_STRING)
+                message = info[i].value.data.string;
+        }
+    }
+    shell_warn ("notify source=%s.%d event-status=%d%s%s",
+               source.nspace,
+               source.rank,
+               status,
+               message ? " " : "",
+               message ? message : "");
+#if 0
+    /* Calling the callback seems to cause a segfault in
+     * the server progress_local_event_hdlr().  Perhaps we're doing it wrong.
+     * In test, PMIx_Notify_event() is released anyway, contrary to v5 spec.
+     * Revisit if that test starts hanging.
+     */
+    if (cbfunc)
+        cbfunc (PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, cbdata, NULL);
+#endif
+done:
+    codec_info_array_destroy (info, ninfo);
+    codec_info_array_destroy (results, nresults);
+}
+
+
+static void notify_server_cb (size_t evhdlr_registration_id,
+                             pmix_status_t status,
+                             const pmix_proc_t *source,
+                             pmix_info_t info[],
+                             size_t ninfo,
+                             pmix_info_t results[],
+                             size_t nresults,
+                             pmix_event_notification_cbfunc_fn_t cbfunc,
+                             void *cbdata)
+{
+    struct notify *notify = global_notify_ctx;
+
+    json_t *xsource = NULL;
+    json_t *xinfo = NULL;
+    json_t *xresults = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+
+    if (!(xsource = codec_proc_encode (source))
+        || !(xinfo = codec_info_array_encode (info, ninfo))
+        || !(xresults = codec_info_array_encode (results, nresults))
+        || !(xcbfunc = codec_pointer_encode (cbfunc))
+        || !(xcbdata = codec_pointer_encode (cbdata))
+        || interthread_send_pack (notify->it,
+                                  "notify_upcall",
+                                  "{s:i s:i s:O s:O s:O s:O s:O}",
+                                  "id", evhdlr_registration_id,
+                                  "status", status,
+                                  "source", xsource,
+                                  "info", xinfo,
+                                  "results", xresults,
+                                  "cbfunc", xcbfunc,
+                                  "cbdata", xcbdata) < 0) {
+        fprintf (stderr, "error sending notify_upcall interthread message\n");
+        return;
+    }
+    json_decref (xsource);
+    json_decref (xinfo);
+    json_decref (xresults);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+}
+
+void notify_destroy (struct notify *notify)
+{
+    if (notify) {
+        int saved_errno = errno;
+        if (notify->id >= 0)
+            PMIx_Deregister_event_handler (notify->id, NULL, NULL);
+        free (notify);
+        errno = saved_errno;
+        global_notify_ctx = NULL;
+    }
+}
+
+struct notify *notify_create (flux_shell_t *shell, struct interthread *it)
+{
+    struct notify *notify;
+
+    if (!(notify = calloc (1, sizeof (*notify))))
+        return NULL;
+    notify->shell = shell;
+    notify->it = it;
+    if ((notify->id = PMIx_Register_event_handler (NULL,
+                                                   0,
+                                                   NULL,
+                                                   0,
+                                                   notify_server_cb,
+                                                   NULL,
+                                                   NULL)) < 0) {
+        shell_warn ("PMIx_Register_event_handler: %s",
+                    PMIx_Error_string (-1 * notify->id));
+        goto error;
+    }
+    if (interthread_register (it, "notify_upcall", notify_shell_cb, notify) < 0)
+        goto error;
+    global_notify_ctx = notify;
+    return notify;
+error:
+    notify_destroy (notify);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/notify.h
+++ b/src/shell/plugins/notify.h
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_NOTIFY_H
+#define _PX_NOTIFY_H
+
+#include <pmix.h>
+#include <pmix_server.h>
+#include "interthread.h"
+
+/* N.B. notify_create() must be called after PMIx_server_init().
+ */
+struct notify *notify_create (flux_shell_t *shell, struct interthread *it);
+void notify_destroy (struct notify *notify);
+
+#endif // _PX_NOTIFY_H
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -28,7 +28,8 @@ TESTSCRIPTS = \
 	t0002-basic.t \
 	t0003-barrier.t \
 	t0004-bizcard.t \
-	t0005-abort.t
+	t0005-abort.t \
+	t0006-notify.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -14,6 +14,7 @@ check_PROGRAMS = \
 	version \
 	getkey \
 	abort \
+	notify \
 	mpi_hello \
 	mpi_version \
 	mpi_abort
@@ -55,6 +56,10 @@ getkey_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
 abort_SOURCES = abort.c
 abort_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
 abort_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
+
+notify_SOURCES = notify.c
+notify_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
+notify_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
 
 mpi_hello_SOURCES = mpi_hello.c
 mpi_hello_CPPFLAGS = $(AM_CPPFLAGS) $(OMPI_CFLAGS)

--- a/t/src/notify.c
+++ b/t/src/notify.c
@@ -1,0 +1,113 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+/* notify.c - call PMIx_Notify_event()
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pmix.h>
+#include <stdio.h>
+#include <flux/optparse.h>
+
+#include "log.h"
+
+const char *opt_usage = "[OPTIONS]";
+
+static struct optparse_option opts[] = {
+    { .name = "status", .has_arg = 1, .arginfo = "INT",
+      .usage = "set event status code (default=0)",
+    },
+    { .name = "message", .has_arg = 1, .arginfo = "TEXT",
+      .usage = "set event message (default=none)",
+    },
+    OPTPARSE_TABLE_END,
+};
+
+int main (int argc, char **argv)
+{
+    optparse_t *p;
+    int optindex;
+    pmix_proc_t self;
+    int event_status;
+    const char *event_message;
+    pmix_info_t info[1] = { 0 };
+    size_t ninfo = 0;
+    int rc;
+
+    /* Parse args
+     */
+    if (!(p = optparse_create ("abort"))
+        || optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS
+        || optparse_set (p, OPTPARSE_USAGE, opt_usage) != OPTPARSE_SUCCESS)
+        log_msg_exit ("error setting up option parsing");
+    if ((optindex = optparse_parse_args (p, argc, argv)) < 0)
+        return 1;
+    if (optindex != argc) {
+        optparse_print_usage (p);
+        return 1;
+    }
+    event_status = optparse_get_int (p, "status", 0);
+    event_message = optparse_get_str (p, "message", NULL);
+
+    /* Initialize and set log prefix to nspace.rank
+     */
+    char name[512];
+    if ((rc = PMIx_Init (&self, NULL, 0)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Init: %s", PMIx_Error_string (rc));
+    snprintf (name, sizeof (name), "%s.%d", self.nspace, self.rank);
+    log_init (name);
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Init.");
+
+    /* Get the size and print it so we know the test wired up.
+     */
+    pmix_proc_t proc;
+    pmix_value_t *valp;
+    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
+    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    proc.rank = PMIX_RANK_WILDCARD;
+    if ((rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &valp)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Get %s: %s", PMIX_JOB_SIZE, PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("there are %d tasks",
+                 valp->type == PMIX_UINT32 ? valp->data.uint32 : -1);
+    PMIX_VALUE_RELEASE (valp);
+
+    /* Add any info options
+     */
+    if (event_message) {
+        strncpy (info[ninfo].key, PMIX_EVENT_TEXT_MESSAGE, PMIX_MAX_KEYLEN);
+        info[ninfo].value.type = PMIX_STRING;
+        info[ninfo].value.data.string = (char *)event_message;
+        ninfo++;
+    }
+    if ((rc = PMIx_Notify_event (event_status,
+                                 &self,
+                                 PMIX_RANGE_GLOBAL,
+                                 info,
+                                 ninfo,
+                                 NULL,
+                                 NULL)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Notify_event: %s", PMIx_Error_string (rc));
+
+    /* Finalize
+     */
+    if ((rc = PMIx_Finalize (NULL, 0)))
+        log_msg_exit ("PMIx_Finalize: %s", PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Finalize.");
+
+    optparse_destroy (p);
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t0006-notify.t
+++ b/t/t0006-notify.t
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+test_description='Exercise server error callback for event notification'
+
+PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
+
+. `dirname $0`/sharness.sh
+
+NOTIFY=${FLUX_BUILD_DIR}/t/src/notify
+
+test_under_flux 2
+
+test_expect_success 'create rc.lua script' "
+	cat >rc.lua <<-EOT
+	plugin.load (\"$PLUGINPATH/pmix.so\")
+	EOT
+"
+
+# N.B. if these tests start hanging, perhaps openpmix has caught up
+# with the spec (see comment in plugin notify.c)
+test_expect_success '1n1p event notify triggers warning on stderr' '
+	run_timeout 30 flux mini run \
+		-ouserrc=$(pwd)/rc.lua \
+		${NOTIFY} --status=69 2>warn.err &&
+	grep event-status=69 warn.err
+'
+
+test_expect_success '1n1p event notify with message works' '
+	run_timeout 30 flux mini run \
+		-ouserrc=$(pwd)/rc.lua \
+		${NOTIFY} --status=69 --message="lorem ipsum" 2>message.err &&
+	grep "lorem ipsum" message.err
+'
+
+test_done


### PR DESCRIPTION
This adds a hook that allows openpmix to notify the shell plugin of any internal errors.  The errors are logged with `shell_warn()`.

This is based on top of #16 (abort) and will need to be rebased once that is merged.