### PR TITLE
ci: fix typo in mergify.yml, support fedora34 docker build

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - status-success="validate commits"
       - status-success="focal - ompi v5.0.x"
       - status-success="focal - ompi v5.0.x, chain_lint"
-      - status-success="centos8 - ommpi v5.0.x, distcheck"
+      - status-success="centos8 - ompi v5.0.x, distcheck"
       - status-success="coverage"
       - label="merge-when-passing"
       - label!="work-in-progress"

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -1,0 +1,41 @@
+FROM fluxrm/flux-core:fedora34
+
+ARG USER=fluxuser
+ARG UID=1000
+ARG OMPI_BRANCH=v5.0.x
+
+RUN \
+ if test "$USER" != "fluxuser"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER \
+   && sudo usermod -G wheel fluxuser ; \
+ fi
+
+# install ompi prereqs
+RUN sudo yum -y update \
+ && sudo yum -y install \
+    flex \
+    libevent-devel \
+    zlib-devel \
+ && sudo yum -y remove mpich mpich-devel \
+ && sudo yum clean all
+
+# build/install ompi
+RUN cd /tmp \
+ && git clone -b ${OMPI_BRANCH} \
+      --recursive --depth=1 https://github.com/open-mpi/ompi \
+ && cd ompi \
+ && git branch \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --disable-man-pages --enable-debug --enable-mem-debug \
+ && make -j $(nproc) \
+ && sudo make install \
+ && cd .. \
+ && rm -rf ompi
+
+USER $USER
+WORKDIR /home/$USER
+


### PR DESCRIPTION
Apologies, this PR fixes another typo in the CI setup. The name of centos8 builder had `ommpi` instead of `ompi`.

Also I threw in a Dockerfile for fedora34 here. We can't use this for ci yet, because many tests fail in this environment. However, perhaps when someone who knows what they are doing has time, they could try to determine what in the Fedora 34 docker environment is causing the failures:

(I'd understand if you want the addition of the fedora34 Dockerfile in a different PR, just let me know)

```
bash-5.1$ ./t0003-barrier.t -d -v
sharness: loading extensions from /usr/src/t/sharness.d/00-setup.sh
sharness: loading extensions from /usr/src/t/sharness.d/01-setup.sh
sharness: loading extensions from /usr/src/t/sharness.d/flux-sharness.sh
sharness: loading extensions from /usr/src/t/sharness.d/00-setup.sh
sharness: loading extensions from /usr/src/t/sharness.d/01-setup.sh
sharness: loading extensions from /usr/src/t/sharness.d/flux-sharness.sh
expecting success: 
	${VERSION}

ok 1 - print pmix library version

expecting success: 
	cat >rc.lua <<-EOT
	plugin.load ("/usr/src/src/shell/plugins/.libs/pmix.so")
	EOT

ok 2 - create rc.lua script

expecting success: 
	run_timeout 30 flux mini run -N1 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER}

fT2EPt3.0: completed PMIx_Init.
fT2EPt3.0: there are 2 tasks
fT2EPt3.0: PMIx_Fence: BAD-PARAM
fT2EPt3.1: PMIx_Fence: BAD-PARAM
flux-job: task(s) exited with exit code 1
not ok 3 - 1n2p barrier works
#	
#		run_timeout 30 flux mini run -N1 -n2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER}
#	

expecting success: 
	run_timeout 30 flux mini run -N1 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --timeout=2s

fbBASn3.0: completed PMIx_Init.
fbBASn3.0: there are 2 tasks
fbBASn3.0: PMIx_Fence: BAD-PARAM
fbBASn3.1: PMIx_Fence: BAD-PARAM
flux-job: task(s) exited with exit code 1
not ok 4 - 1n2p barrier tolerates pmix.timeout=2
#	
#		run_timeout 30 flux mini run -N1 -n2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER} --timeout=2s
#	

expecting success: 
	run_timeout 30 flux mini run -N1 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --collect-data=false

fjUzRN7.0: completed PMIx_Init.
fjUzRN7.0: there are 2 tasks
fjUzRN7.0: PMIx_Fence: BAD-PARAM
fjUzRN7.1: PMIx_Fence: BAD-PARAM
flux-job: task(s) exited with exit code 1
not ok 5 - 1n2p barrier tolerates pmix.collect=false
#	
#		run_timeout 30 flux mini run -N1 -n2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER} --collect-data=false
#	

skipping test: 1n2p barrier rejects required unknown option 
	test_must_fail run_timeout 30 flux mini run -N1 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --unknown=+42

ok 6 # skip 1n2p barrier rejects required unknown option (missing XFAIL)

expecting success: 
	run_timeout 30 flux mini run -N1 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --collect-job-info=false

fspJPEX.0: completed PMIx_Init.
fspJPEX.0: there are 2 tasks
fspJPEX.1: PMIx_Fence: BAD-PARAM
fspJPEX.0: PMIx_Fence: BAD-PARAM
flux-job: task(s) exited with exit code 1
not ok 7 - 1n2p barrier tolerates pmix.collect.gen=false
#	
#		run_timeout 30 flux mini run -N1 -n2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER} --collect-job-info=false
#	

expecting success: 
	run_timeout 30 flux mini run -N1 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --procs=0

f22FYJEK.0: completed PMIx_Init.
f22FYJEK.0: there are 2 tasks
f22FYJEK.0: completed barrier in 0.000s.
f22FYJEK.0: completed PMIx_Finalize.
ok 8 - 1n2p barrier with procs subset works

expecting success: 
	run_timeout 30 flux mini run -N2 -n2 \
		-overbose=2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER}

0.032s: flux-shell[1]: DEBUG: 1: tasks [1] on cores 0
0.033s: flux-shell[1]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.067s: flux-shell[1]: DEBUG: pmix: local_peers = 1
0.067s: flux-shell[1]: DEBUG: pmix: node_map = asp0,asp1
0.067s: flux-shell[1]: DEBUG: pmix: proc_map = 0;1
0.070s: flux-shell[1]: TRACE: shell barrier complete
0.070s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.082s: flux-shell[1]: TRACE: shell barrier complete
0.082s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.026s: flux-shell[0]: DEBUG: 0: task_count=2 slot_count=2 cores_per_slot=1 slots_per_node=1
0.026s: flux-shell[0]: DEBUG: 0: tasks [0] on cores 0
0.027s: flux-shell[0]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.033s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s
0.058s: flux-shell[0]: DEBUG: pmix: local_peers = 0
0.058s: flux-shell[0]: DEBUG: pmix: node_map = asp0,asp1
0.059s: flux-shell[0]: DEBUG: pmix: proc_map = 0;1
0.070s: flux-shell[0]: TRACE: shell barrier complete
0.070s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.081s: flux-shell[0]: TRACE: shell barrier complete
0.082s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.105s: flux-shell[1]: TRACE: 1: C: pmi EOF
0.105s: flux-shell[1]: DEBUG: task 1 complete status=1
0.117s: flux-shell[1]: DEBUG: exit 1
f2AcLFP5.1: PMIx_Fence: BAD-PARAM
f2AcLFP5.0: completed PMIx_Init.
f2AcLFP5.0: there are 2 tasks
f2AcLFP5.0: PMIx_Fence: BAD-PARAM
0.118s: flux-shell[0]: TRACE: 0: C: pmi EOF
0.124s: flux-shell[0]: DEBUG: task 0 complete status=1
0.130s: flux-shell[0]: DEBUG: exit 1
flux-job: task(s) exited with exit code 1
not ok 9 - 2n2p barrier works
#	
#		run_timeout 30 flux mini run -N2 -n2 \
#			-overbose=2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER}
#	

expecting success: 
	run_timeout 30 flux mini run -N2 -n2 \
		-overbose=2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --timeout=2s

0.031s: flux-shell[1]: DEBUG: 1: tasks [1] on cores 0
0.032s: flux-shell[1]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.067s: flux-shell[1]: DEBUG: pmix: local_peers = 1
0.067s: flux-shell[1]: DEBUG: pmix: node_map = asp0,asp1
0.067s: flux-shell[1]: DEBUG: pmix: proc_map = 0;1
0.070s: flux-shell[1]: TRACE: shell barrier complete
0.070s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.080s: flux-shell[1]: TRACE: shell barrier complete
0.080s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.027s: flux-shell[0]: DEBUG: 0: task_count=2 slot_count=2 cores_per_slot=1 slots_per_node=1
0.027s: flux-shell[0]: DEBUG: 0: tasks [0] on cores 0
0.028s: flux-shell[0]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.034s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s
0.062s: flux-shell[0]: DEBUG: pmix: local_peers = 0
0.062s: flux-shell[0]: DEBUG: pmix: node_map = asp0,asp1
0.062s: flux-shell[0]: DEBUG: pmix: proc_map = 0;1
0.070s: flux-shell[0]: TRACE: shell barrier complete
0.070s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.080s: flux-shell[0]: TRACE: shell barrier complete
0.080s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.103s: flux-shell[0]: TRACE: 0: C: pmi EOF
0.103s: flux-shell[0]: DEBUG: task 0 complete status=1
f2LFFad5.0: completed PMIx_Init.
f2LFFad5.0: there are 2 tasks
f2LFFad5.0: PMIx_Fence: BAD-PARAM
f2LFFad5.1: PMIx_Fence: BAD-PARAM
0.117s: flux-shell[0]: DEBUG: exit 1
0.115s: flux-shell[1]: TRACE: 1: C: pmi EOF
0.115s: flux-shell[1]: DEBUG: task 1 complete status=1
0.127s: flux-shell[1]: DEBUG: exit 1
flux-job: task(s) exited with exit code 1
not ok 10 - 2n2p barrier tolerates optional pmix.timeout=2
#	
#		run_timeout 30 flux mini run -N2 -n2 \
#			-overbose=2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER} --timeout=2s
#	

expecting success: 
	run_timeout 30 flux mini run -N2 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --collect-data=false

f2W62p7q.0: completed PMIx_Init.
f2W62p7q.0: there are 2 tasks
f2W62p7q.0: PMIx_Fence: BAD-PARAM
f2W62p7q.1: PMIx_Fence: BAD-PARAM
flux-job: task(s) exited with exit code 1
not ok 11 - 2n2p barrier tolerates optional pmix.collect=false
#	
#		run_timeout 30 flux mini run -N2 -n2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER} --collect-data=false
#	

expecting success: 
	run_timeout 30 flux mini run -N2 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --collect-job-info=false

f2h43W1m.0: completed PMIx_Init.
f2h43W1m.0: there are 2 tasks
f2h43W1m.0: PMIx_Fence: BAD-PARAM
f2h43W1m.1: PMIx_Fence: BAD-PARAM
flux-job: task(s) exited with exit code 1
not ok 12 - 2n2p barrier tolerates optional pmix.collect.gen=false
#	
#		run_timeout 30 flux mini run -N2 -n2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER} --collect-job-info=false
#	

skipping test: 2n2p barrier rejects required pmix.collect.gen=false 
	test_must_fail run_timeout 30 flux mini run -N2 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		-overbose=2 \
		${BARRIER} --collect-job-info=+false

ok 13 # skip 2n2p barrier rejects required pmix.collect.gen=false (missing XFAIL)

expecting success: 
	run_timeout 30 flux mini run -N2 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER} --unknown=42

f2rdzrh5.1: PMIx_Fence: BAD-PARAM
f2rdzrh5.0: completed PMIx_Init.
f2rdzrh5.0: there are 2 tasks
f2rdzrh5.0: PMIx_Fence: BAD-PARAM
flux-job: task(s) exited with exit code 1
not ok 14 - 2n2p barrier tolerates optional unknown attr
#	
#		run_timeout 30 flux mini run -N2 -n2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER} --unknown=42
#	

skipping test: 2n2p barrier with procs subset fails 
	test_must_fail run_timeout 30 flux mini run -N2 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		-overbose=2 \
		${BARRIER} --procs=1

ok 15 # skip 2n2p barrier with procs subset fails (missing XFAIL)

expecting success: 
	test_must_fail run_timeout 30 flux mini run -N2 -n2 \
		-ouserrc=$(pwd)/rc.lua \
		-overbose=2 \
		${BARRIER} --procs=0-1

0.031s: flux-shell[1]: DEBUG: 1: tasks [1] on cores 0
0.032s: flux-shell[1]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.066s: flux-shell[1]: DEBUG: pmix: local_peers = 1
0.066s: flux-shell[1]: DEBUG: pmix: node_map = asp0,asp1
0.066s: flux-shell[1]: DEBUG: pmix: proc_map = 0;1
0.070s: flux-shell[1]: TRACE: shell barrier complete
0.070s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.083s: flux-shell[1]: TRACE: shell barrier complete
0.083s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.027s: flux-shell[0]: DEBUG: 0: task_count=2 slot_count=2 cores_per_slot=1 slots_per_node=1
0.027s: flux-shell[0]: DEBUG: 0: tasks [0] on cores 0
0.028s: flux-shell[0]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.034s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s
0.066s: flux-shell[0]: DEBUG: pmix: local_peers = 0
0.066s: flux-shell[0]: DEBUG: pmix: node_map = asp0,asp1
0.066s: flux-shell[0]: DEBUG: pmix: proc_map = 0;1
0.070s: flux-shell[0]: TRACE: shell barrier complete
0.070s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.083s: flux-shell[0]: TRACE: shell barrier complete
0.083s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.101s: flux-shell[0]: TRACE: pmix server fence_upcall {"procs":[{"nspace":"f32FSCej","rank":0},{"nspace":"f32FSCej","rank":1}],"info":[],"data":"CQIbBAkCAgA=","cbfunc":140215632572587,"cbdata":140215515711296}
0.102s: flux-shell[0]:  WARN: fence over proc subset is not supported by flux
0.102s: flux-shell[0]: TRACE: 0: C: pmi EOF
0.103s: flux-shell[0]: DEBUG: task 0 complete status=1
f32FSCej.0: completed PMIx_Init.
f32FSCej.0: there are 2 tasks
f32FSCej.0: PMIx_Fence: NOT-SUPPORTED
f32FSCej.1: PMIx_Fence: NOT-SUPPORTED
0.117s: flux-shell[0]: DEBUG: exit 1
0.114s: flux-shell[1]: TRACE: pmix server fence_upcall {"procs":[{"nspace":"f32FSCej","rank":0},{"nspace":"f32FSCej","rank":1}],"info":[],"data":"CQIbBAkCAgA=","cbfunc":139755525742763,"cbdata":139755350230848}
0.114s: flux-shell[1]:  WARN: fence over proc subset is not supported by flux
0.115s: flux-shell[1]: TRACE: 1: C: pmi EOF
0.115s: flux-shell[1]: DEBUG: task 1 complete status=1
0.126s: flux-shell[1]: DEBUG: exit 1
flux-job: task(s) exited with exit code 1
ok 16 - 2n2p barrier with procs explictly set fails

expecting success: 
	run_timeout 30 flux mini run -N2 -n4 \
		-overbose=2 \
		-ouserrc=$(pwd)/rc.lua \
		${BARRIER}

0.026s: flux-shell[0]: DEBUG: 0: task_count=4 slot_count=4 cores_per_slot=1 slots_per_node=2
0.026s: flux-shell[0]: DEBUG: 0: tasks [0-1] on cores 0-1
0.028s: flux-shell[0]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.034s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s
0.060s: flux-shell[0]: DEBUG: pmix: local_peers = 0,1
0.060s: flux-shell[0]: DEBUG: pmix: node_map = asp0,asp1
0.060s: flux-shell[0]: DEBUG: pmix: proc_map = 0,1;2,3
0.066s: flux-shell[0]: TRACE: shell barrier complete
0.066s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.091s: flux-shell[0]: TRACE: shell barrier complete
0.091s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.031s: flux-shell[1]: DEBUG: 1: tasks [2-3] on cores 0-1
0.032s: flux-shell[1]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.062s: flux-shell[1]: DEBUG: pmix: local_peers = 2,3
0.063s: flux-shell[1]: DEBUG: pmix: node_map = asp0,asp1
0.063s: flux-shell[1]: DEBUG: pmix: proc_map = 0,1;2,3
0.066s: flux-shell[1]: TRACE: shell barrier complete
0.066s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.092s: flux-shell[1]: TRACE: shell barrier complete
0.092s: flux-shell[1]: TRACE: exited barrier with rc = 0
f3BuqXB5.2: PMIx_Fence: BAD-PARAM
f3BuqXB5.3: PMIx_Fence: BAD-PARAM
f3BuqXB5.0: completed PMIx_Init.
f3BuqXB5.0: there are 4 tasks
f3BuqXB5.1: PMIx_Fence: BAD-PARAM
f3BuqXB5.0: PMIx_Fence: BAD-PARAM
0.102s: flux-shell[1]: TRACE: 2: C: pmi EOF
0.102s: flux-shell[1]: DEBUG: task 2 complete status=1
0.104s: flux-shell[1]: TRACE: 3: C: pmi EOF
0.104s: flux-shell[1]: DEBUG: task 3 complete status=1
0.115s: flux-shell[1]: DEBUG: exit 1
0.112s: flux-shell[0]: TRACE: 0: C: pmi EOF
0.112s: flux-shell[0]: DEBUG: task 0 complete status=1
0.112s: flux-shell[0]: TRACE: 1: C: pmi EOF
0.114s: flux-shell[0]: DEBUG: task 1 complete status=1
0.124s: flux-shell[0]: DEBUG: exit 1
flux-job: task(s) exited with exit code 1
not ok 17 - 2n4p barrier works
#	
#		run_timeout 30 flux mini run -N2 -n4 \
#			-overbose=2 \
#			-ouserrc=$(pwd)/rc.lua \
#			${BARRIER}
#	

# failed 10 among 17 test(s)
1..17
2021-09-24T16:42:33.588657Z broker.err[0]: rc2.0: /bin/bash -c sh ./t0003-barrier.t  --verbose --debug Exited (rc=1) 4.7s
flux-start: 0 (pid 4992) exited with rc=1
```

