### PR TITLE
fix bug in exchange class

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,11 @@ jobs:
           coverage: true
           env:
             COVERAGE: t
+        - name: "fedora34 - ompi v5.0.x"
+          image: "fedora34"
+          ompi_branch: "v5.0.x"
+          coverage: false
+          env: {}
 
       fail-fast: false
     name: ${{ matrix.name }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,6 +7,7 @@ pull_request_rules:
       - status-success="focal - ompi v5.0.x, chain_lint"
       - status-success="centos8 - ompi v5.0.x, distcheck"
       - status-success="coverage"
+      - status-success="fedora34 - ompi v5.0.x"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"

--- a/src/shell/plugins/codec.c
+++ b/src/shell/plugins/codec.c
@@ -90,6 +90,17 @@ int codec_data_decode (json_t *o, void **datap, size_t *lengthp)
     return 0;
 }
 
+ssize_t codec_data_length (json_t *o)
+{
+    void *data;
+    size_t length;
+    if (codec_data_decode (o, &data, &length) < 0)
+        return -1;
+    free (data);
+    return length;
+}
+
+
 json_t *codec_proc_encode (const pmix_proc_t *proc)
 {
     return json_pack ("{s:s s:i}",

--- a/src/shell/plugins/codec.h
+++ b/src/shell/plugins/codec.h
@@ -19,6 +19,7 @@ int codec_pointer_decode (json_t *o, void **ptr);
 
 json_t *codec_data_encode (const void *data, size_t length);
 int codec_data_decode (json_t *o, void **data, size_t *length);
+ssize_t codec_data_length (json_t *o);
 
 ssize_t codec_data_decode_bufsize (json_t *o);
 ssize_t codec_data_decode_tobuf (json_t *o, void *data, size_t buflen);

--- a/src/shell/plugins/exchange.c
+++ b/src/shell/plugins/exchange.c
@@ -158,7 +158,7 @@ static void session_process (struct session *ses)
     if (ses->f && !flux_future_is_ready (ses->f))
         return;
 
-    if (xcg->rank == 0);
+    if (xcg->rank == 0)
         ses->data_out = json_incref (ses->data_in);
 
     /* Send exchange response(s), if needed.

--- a/src/shell/plugins/exchange.c
+++ b/src/shell/plugins/exchange.c
@@ -238,9 +238,8 @@ int exchange_enter_base64_string (struct exchange *xcg,
                                   void *exit_cb_arg)
 {
     if (!xcg
-        || !data
         || !exit_cb
-        || !json_is_string (data)) {
+        || (data && !json_is_string (data))) {
         errno = EINVAL;
         return -1;
     }
@@ -255,9 +254,11 @@ int exchange_enter_base64_string (struct exchange *xcg,
     xcg->session->exit_cb = exit_cb;
     xcg->session->exit_cb_arg = exit_cb_arg;
     xcg->session->local = 1;
-    if (json_array_append (xcg->session->data_in, data) < 0) {
-        errno = ENOMEM;
-        return -1;
+    if (data) {
+        if (json_array_append (xcg->session->data_in, data) < 0) {
+            errno = ENOMEM;
+            return -1;
+        }
     }
     session_process (xcg->session);
     return 0;

--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -82,10 +82,12 @@ static void exchange_exit_cb (struct exchange *xcg, void *arg)
         shell_warn ("error accessing pmix exchanged data");
         goto done;
     }
-    shell_trace ("completed pmix exchange");
     status = PMIX_SUCCESS;
 done:
     // N.B. pmix calls 'free' on data when fence is complete
+    shell_trace ("completed pmix exchange: size %zu %s",
+                 ndata,
+                 PMIx_Error_string (status));
     fxcall->cbfunc (status, data, ndata, fxcall->cbdata, free, data);
 }
 
@@ -163,7 +165,8 @@ static void fence_shell_cb (const flux_msg_t *msg, void *arg)
         goto error;
     }
     if (fx->trace_flag)
-        shell_trace ("starting pmix exchange");
+        shell_trace ("starting pmix exchange: size %zi",
+                     codec_data_length (xdata));
     return;
 error:
     fxcall->cbfunc (rc, NULL, 0, fxcall->cbdata, NULL, NULL);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -29,7 +29,8 @@ TESTSCRIPTS = \
 	t0003-barrier.t \
 	t0004-bizcard.t \
 	t0005-abort.t \
-	t0006-notify.t
+	t0006-notify.t \
+	t1000-ompi-basic.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/src/barrier.c
+++ b/t/src/barrier.c
@@ -72,11 +72,10 @@ void set_info_int (pmix_info_t *info,
 size_t parse_info_opts (optparse_t *p, pmix_info_t *infos, size_t ninfo)
 {
     size_t count = 0;
-    const char *arg;
-    int flags = 0;
 
     if (optparse_hasopt (p, "collect-data")) {
-        arg = optparse_get_str (p, "collect-data", "true");
+        const char *arg = optparse_get_str (p, "collect-data", "true");
+        int flags = 0;
         if (*arg == '+') {
             flags |= PMIX_INFO_REQD;
             arg++;
@@ -86,7 +85,8 @@ size_t parse_info_opts (optparse_t *p, pmix_info_t *infos, size_t ninfo)
         set_info_bool (&infos[count++], PMIX_COLLECT_DATA, flags, arg);
     }
     if (optparse_hasopt (p, "collect-job-info")) {
-        arg = optparse_get_str (p, "collect-job-info", "true");
+        const char *arg = optparse_get_str (p, "collect-job-info", "true");
+        int flags = 0;
         if (*arg == '+') {
             flags |= PMIX_INFO_REQD;
             arg++;
@@ -99,7 +99,8 @@ size_t parse_info_opts (optparse_t *p, pmix_info_t *infos, size_t ninfo)
                        arg);
     }
     if (optparse_hasopt (p, "timeout")) {
-        arg = optparse_get_str (p, "timeout", "0");
+        const char *arg = optparse_get_str (p, "timeout", "0");
+        int flags = 0;
         if (*arg == '+') {
             flags |= PMIX_INFO_REQD;
             arg++;
@@ -112,7 +113,8 @@ size_t parse_info_opts (optparse_t *p, pmix_info_t *infos, size_t ninfo)
                       strtol (arg, NULL, 10));
     }
     if (optparse_hasopt (p, "unknown")) {
-        arg = optparse_get_str (p, "unknown", "0");
+        const char *arg = optparse_get_str (p, "unknown", "0");
+        int flags = 0;
         if (*arg == '+') {
             flags |= PMIX_INFO_REQD;
             arg++;

--- a/t/src/barrier.c
+++ b/t/src/barrier.c
@@ -205,7 +205,7 @@ int main (int argc, char **argv)
     struct timespec t;
     monotime (&t);
     pmix_info_t info[8] = { 0 };
-    pmix_proc_t *procs;
+    pmix_proc_t *procs = NULL;
     size_t ninfo = parse_info_opts (p, info, sizeof (info) / sizeof (info[0]));
     size_t nprocs = parse_procs_opt (p, &self, &procs);
 

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+test_description='Test openmpi bootstrap.'
+
+PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
+
+. `dirname $0`/sharness.sh
+
+MPI_HELLO=${FLUX_BUILD_DIR}/t/src/mpi_hello
+
+test_under_flux 2
+
+test_expect_success 'create rc.lua script' "
+	cat >rc.lua <<-EOT
+	plugin.load (\"$PLUGINPATH/pmix.so\")
+	EOT
+"
+
+test_expect_success '1n2p ompi hello' '
+	run_timeout 30 flux mini run -N1 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		-ompi=openmpi@5 \
+		${MPI_HELLO}
+'
+
+test_expect_success '2n2p ompi hello' '
+	run_timeout 30 flux mini run -N2 -n2 \
+		-ouserrc=$(pwd)/rc.lua \
+		-ompi=openmpi@5 \
+		${MPI_HELLO}
+'
+
+test_done


### PR DESCRIPTION
This PR fixes a bug in the fence callback - actually in the exchange class it uses - where a conditional became unconditional due to a stray semi-colon, and as a result, all ranks did not receive the entire aggregate data blob at the conclusion of the exchange.

With that fixed, ompi hello world works on two shells!  So a new sharness test that does that is added.

There is also some improved debug output, and an improvement to the barrier use case for `PMIx_Fence()`, where data was being gratuitously exchanged by the `fence_nb` server callback when it was not requested by the user.