### PR TITLE
add mpi personality script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@ SUBDIRS = \
 	src/common/libtap \
 	src/common/libccan \
 	src/shell/plugins \
+	src/shell/lua.d \
 	t
 
 EXTRA_DIST = \

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,9 @@ PKG_CHECK_MODULES([OMPI], [ompi >= 5.0.0], [
 AX_FLUX_CORE
 AX_CODE_COVERAGE
 
+AS_VAR_SET(shell_luadir, $sysconfdir/flux/shell/lua.d)
+AC_SUBST(shell_luadir)
+
 AS_VAR_SET(shell_plugindir, $libdir/flux/shell/plugins)
 AC_SUBST(shell_plugindir)
 
@@ -78,6 +81,7 @@ AC_CONFIG_FILES( \
   src/common/libtap/Makefile \
   src/common/libccan/Makefile \
   src/shell/plugins/Makefile \
+  src/shell/lua.d/Makefile \
   t/Makefile \
   t/sharness.d/00-setup.sh \
   t/src/Makefile \

--- a/src/shell/lua.d/Makefile.am
+++ b/src/shell/lua.d/Makefile.am
@@ -1,0 +1,3 @@
+dist_shell_lua_SCRIPTS = \
+	openmpi@5.lua
+

--- a/src/shell/lua.d/openmpi@5.lua
+++ b/src/shell/lua.d/openmpi@5.lua
@@ -1,0 +1,15 @@
+-------------------------------------------------------------
+-- Copyright 2021 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+
+local mpi, version = shell.getopt_with_version ("mpi")
+
+if mpi ~= "openmpi" or version ~= "5" then return end
+
+plugin.load ("pmix/pmix.so")

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir)
 
-shell_plugin_LTLIBRARIES = \
+shell_plugin_subdir = \
+	$(shell_plugindir)/pmix
+shell_plugin_sub_LTLIBRARIES = \
 	pmix.la
 
 pmix_la_SOURCES = \


### PR DESCRIPTION
This just adds a small lua script to load `pmix.so` when the user specifies `-ompi=openmpi@5`.  Tested when installed to the same prefix as current flux-core master.

Easily changed if we decide to do something more structured with these mpi personality scripts.