### PR TITLE
avoid unlink errors on mpi teardown

### DIFF
--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -206,7 +206,6 @@ static int px_init (flux_plugin_t *p,
         || set_node_map (iv, PMIX_NODE_MAP, shell) < 0
         || set_proc_map (iv, PMIX_PROC_MAP, shell) < 0
         || infovec_set_bool (iv, PMIX_TDIR_RMCLEAN, true) < 0
-        || infovec_set_str (iv, PMIX_NSDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_JOB_NUM_APPS, 1) < 0
         || infovec_set_str (iv, PMIX_TMPDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_LOCAL_SIZE, px->local_nprocs) < 0

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -210,7 +210,8 @@ static int px_init (flux_plugin_t *p,
         || infovec_set_str (iv, PMIX_TMPDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_LOCAL_SIZE, px->local_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_UNIV_SIZE, px->total_nprocs) < 0
-        || infovec_set_u32 (iv, PMIX_JOB_SIZE, px->total_nprocs) < 0)
+        || infovec_set_u32 (iv, PMIX_JOB_SIZE, px->total_nprocs) < 0
+        || infovec_set_u32 (iv, PMIX_APPNUM, 0) < 0)
         goto error;
 
     if ((rc = PMIx_server_register_nspace (px->nspace,

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -205,6 +205,7 @@ static int px_init (flux_plugin_t *p,
         || set_lpeers (iv, PMIX_LOCAL_PEERS, shell) < 0
         || set_node_map (iv, PMIX_NODE_MAP, shell) < 0
         || set_proc_map (iv, PMIX_PROC_MAP, shell) < 0
+        || infovec_set_bool (iv, PMIX_TDIR_RMCLEAN, true) < 0
         || infovec_set_str (iv, PMIX_NSDIR, px->job_tmpdir) < 0
         || infovec_set_u32 (iv, PMIX_JOB_NUM_APPS, 1) < 0
         || infovec_set_str (iv, PMIX_TMPDIR, px->job_tmpdir) < 0

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -206,5 +206,18 @@ test_expect_success '2n4p pmix.job.napps is set correctly' '
 			| sort -n >pmix.job.napps.out &&
 	test_cmp pmix.job.napps.exp pmix.job.napps.out
 '
+test_expect_success '2n4p pmix.nrank is set correctly' '
+	cat >pmix.nrank.exp <<-EOT &&
+	0: 0
+	1: 1
+	2: 0
+	3: 1
+	EOT
+	run_timeout 30 flux mini run -N2 -n4 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --label-io pmix.nrank \
+			| sort -n >pmix.nrank.out &&
+	test_cmp pmix.nrank.exp pmix.nrank.out
+'
 
 test_done

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -99,10 +99,11 @@ test_expect_success 'pmix.job.napps is set to 1' '
 		${GETKEY} --proc=* pmix.job.napps >pmix.job.napps.out &&
 	test_cmp pmix.job.napps.exp pmix.job.napps.out
 '
-test_expect_success 'pmix.nsdir is set' '
-	run_timeout 30 flux mini run -n1 \
+test_expect_success 'pmix.nsdir is NOT set' '
+	test_must_fail flux mini run \
 		-ouserrc=$(pwd)/rc.lua \
-		${GETKEY} --proc=* pmix.nsdir
+		${GETKEY} --proc=* pmix.nsdir 2>pmix.nsdir.err &&
+	grep NOT-FOUND pmix.nsdir.err
 '
 test_expect_success '2n4p pmix.hname is set' '
 	run_timeout 30 flux mini run -N2 -n4 \

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -219,5 +219,14 @@ test_expect_success '2n4p pmix.nrank is set correctly' '
 			| sort -n >pmix.nrank.out &&
 	test_cmp pmix.nrank.exp pmix.nrank.out
 '
+test_expect_success '1n1p pmix.tdir.rmclean is true' '
+	cat >pmix.tdir.rmclean.exp <<-EOT &&
+	true
+	EOT
+	flux mini run \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --proc=* pmix.tdir.rmclean >pmix.tdir.rmclean.out &&
+	test_cmp pmix.tdir.rmclean.exp pmix.tdir.rmclean.out
+'
 
 test_done

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -193,5 +193,18 @@ test_expect_success '2n4p pmix.appnum is set correctly' '
 			| sort -n >pmix.appnum.out &&
 	test_cmp pmix.appnum.exp pmix.appnum.out
 '
+test_expect_success '2n4p pmix.job.napps is set correctly' '
+	cat >pmix.job.napps.exp <<-EOT &&
+	0: 1
+	1: 1
+	2: 1
+	3: 1
+	EOT
+	run_timeout 30 flux mini run -N2 -n4 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --proc=* --label-io pmix.job.napps \
+			| sort -n >pmix.job.napps.out &&
+	test_cmp pmix.job.napps.exp pmix.job.napps.out
+'
 
 test_done

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -180,5 +180,18 @@ test_expect_success '2n4p pmix.srv.rank is set correctly' '
 			| sort -n >pmix.srv.rank.out &&
 	test_cmp pmix.srv.rank.exp pmix.srv.rank.out
 '
+test_expect_success '2n4p pmix.appnum is set correctly' '
+	cat >pmix.appnum.exp <<-EOT &&
+	0: 0
+	1: 0
+	2: 0
+	3: 0
+	EOT
+	run_timeout 30 flux mini run -N2 -n4 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --proc=* --label-io pmix.appnum \
+			| sort -n >pmix.appnum.out &&
+	test_cmp pmix.appnum.exp pmix.appnum.out
+'
 
 test_done

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -30,4 +30,13 @@ test_expect_success '2n2p ompi hello' '
 		${MPI_HELLO}
 '
 
+# see issue #26
+test_expect_success '2n4p ompi hello reports no system call errors' '
+        run_timeout 30 flux mini run -N2 -n4 \
+                -ouserrc=$(pwd)/rc.lua \
+                -ompi=openmpi@5 \
+                ${MPI_HELLO} 2>2n4p_hello.err &&
+        test_must_fail grep "System call:" 2n4p_hello.err
+'
+
 test_done

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -16,6 +16,22 @@ test_expect_success 'create rc.lua script' "
 	EOT
 "
 
+test_expect_success 'capture the job environment' '
+	run_timeout 30 flux mini run \
+		-ouserrc=$(pwd)/rc.lua \
+		-ompi=openmpi@5 \
+		printenv >printenv.out
+'
+
+test_expect_success 'verify deprecated flux pmix/schizo plugins are not requested' '
+	test_must_fail grep OMPI_MCA_pmix=flux printenv.out &&
+	test_must_fail grep OMPI_MCA_schizo=flux printenv.out
+'
+
+test_expect_success 'sanity check pmix environment' '
+	grep ^PMIX_NAMESPACE printenv.out
+'
+
 test_expect_success '1n2p ompi hello' '
 	run_timeout 30 flux mini run -N1 -n2 \
 		-ouserrc=$(pwd)/rc.lua \


### PR DESCRIPTION
The main thing in this PR is a fix for #26, where `mpi_hello` issues dire warnings about unlink failing.  That looks to be because we set `pmix.nsdir` to the same value as `pmix.tmpdir`, and ompi is trying to clean up `pmix.nsdir` and in the process sweeps away some shared memory segments that some other part of ompi realy wants to clean up.   The solution is to unset `pmix.nsdir`, at least for now.

Other minor attribute tweaks are included:
- setting `pmix.appnum=0`  (ompi asks for it though it is optional)
- setting `pmix.tdir.rmclean=true` (might have fixed the above had ompi checked it)
- adding tests for `pmix.nrank`, `pmix.jobs.napps` (already set properly  - make sure they remain correct)
- verification that old plugins aren't being requested by environment, in case that pops up again later, somehow