### PR TITLE
resolve ompi fence hang

### DIFF
--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -94,6 +94,7 @@ done:
                  ndata,
                  PMIx_Error_string (status));
     fxcall->cbfunc (status, data, ndata, fxcall->cbdata, free, data);
+    fence_call_destroy (fxcall);
 }
 
 /* Parse info[] attributes from the fence callback.

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -151,6 +151,8 @@ static int px_init (flux_plugin_t *p,
                                 "jobid", &px->id,
                                 "rank", &px->shell_rank) < 0)
         return -1;
+    shell_debug ("jobid = %ju", (uintmax_t)px->id);
+    shell_debug ("shell_rank = %d", px->shell_rank);
     if (flux_job_id_encode (px->id, "f58", px->nspace, sizeof (px->nspace)) < 0)
         return -1;
     if (flux_shell_rank_info_unpack (shell,
@@ -159,13 +161,16 @@ static int px_init (flux_plugin_t *p,
                                      "ntasks",
                                      &px->local_nprocs) < 0)
         return -1;
+    shell_debug ("local_nprocs = %d", px->local_nprocs);
     if (flux_shell_jobspec_info_unpack (shell,
                                         "{s:i}",
                                         "ntasks",
                                         &px->total_nprocs) < 0)
         return -1;
+    shell_debug ("total_nprocs = %d", px->total_nprocs);
     if (!(px->job_tmpdir = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR")))
         return -1;
+
 
     if (px->shell_rank == 0) {
         const char *s = PMIx_Get_version ();

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -72,6 +72,18 @@ test_expect_success '2n4p pmix.univ.size is set correctly' '
 			| sort -n >pmix.univ.size.out &&
 	test_cmp pmix.univ.size.exp pmix.univ.size.out
 '
+test_expect_success '2n3p pmix.local.size is set correctly' '
+	cat >2n3p.pmix.local.size.exp <<-EOT &&
+	0: 2
+	1: 2
+	2: 1
+	EOT
+	run_timeout 30 flux mini run -N2 -n3 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --proc=* --label-io pmix.local.size \
+			| sort -n >2n3p.pmix.local.size.out &&
+	test_cmp 2n3p.pmix.local.size.exp 2n3p.pmix.local.size.out
+'
 test_expect_success '2n4p pmix.local.size is set correctly' '
 	cat >pmix.local.size.exp <<-EOT &&
 	0: 2
@@ -111,6 +123,18 @@ test_expect_success '2n4p pmix.hname is set' '
 		${GETKEY} --label-io pmix.hname
 '
 
+test_expect_success '2n3p pmix.lpeers is set correctly' '
+	cat >2n3p.pmix.lpeers.exp <<-EOT &&
+	0: 0,1
+	1: 0,1
+	2: 2
+	EOT
+	run_timeout 30 flux mini run -N2 -n3 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --proc=* --label-io pmix.lpeers \
+			| sort -n >2n3p.pmix.lpeers.out &&
+	test_cmp 2n3p.pmix.lpeers.exp 2n3p.pmix.lpeers.out
+'
 test_expect_success '2n4p pmix.lpeers is set correctly' '
 	cat >pmix.lpeers.exp <<-EOT &&
 	0: 0,1
@@ -142,6 +166,18 @@ test_expect_success '2n4p pmix.num.nodes is set correctly' '
 			| sort -n >pmix.num.nodes.out &&
 	test_cmp pmix.num.nodes.exp pmix.num.nodes.out
 '
+test_expect_success '2n3p pmix.nodeid is set correctly' '
+	cat >2n3p.pmix.nodeid.exp <<-EOT &&
+	0: 0
+	1: 0
+	2: 1
+	EOT
+	run_timeout 30 flux mini run -N2 -n3 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --label-io pmix.nodeid \
+			| sort -n >2n3p.pmix.nodeid.out &&
+	test_cmp 2n3p.pmix.nodeid.exp 2n3p.pmix.nodeid.out
+'
 test_expect_success '2n4p pmix.nodeid is set correctly' '
 	cat >pmix.nodeid.exp <<-EOT &&
 	0: 0
@@ -155,6 +191,18 @@ test_expect_success '2n4p pmix.nodeid is set correctly' '
 			| sort -n >pmix.nodeid.out &&
 	test_cmp pmix.nodeid.exp pmix.nodeid.out
 '
+test_expect_success '2n3p pmix.lrank is set correctly' '
+	cat >2n3p.pmix.lrank.exp <<-EOT &&
+	0: 0
+	1: 1
+	2: 0
+	EOT
+	run_timeout 30 flux mini run -N2 -n3 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --label-io pmix.lrank \
+			| sort -n >2n3p.pmix.lrank.out &&
+	test_cmp 2n3p.pmix.lrank.exp 2n3p.pmix.lrank.out
+'
 test_expect_success '2n4p pmix.lrank is set correctly' '
 	cat >pmix.lrank.exp <<-EOT &&
 	0: 0
@@ -167,6 +215,18 @@ test_expect_success '2n4p pmix.lrank is set correctly' '
 		${GETKEY} --label-io pmix.lrank \
 			| sort -n >pmix.lrank.out &&
 	test_cmp pmix.lrank.exp pmix.lrank.out
+'
+test_expect_success '2n3p pmix.srv.rank is set correctly' '
+	cat >2n3p.pmix.srv.rank.exp <<-EOT &&
+	0: 0
+	1: 0
+	2: 1
+	EOT
+	run_timeout 30 flux mini run -N2 -n3 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --label-io pmix.srv.rank \
+			| sort -n >2n3p.pmix.srv.rank.out &&
+	test_cmp 2n3p.pmix.srv.rank.exp 2n3p.pmix.srv.rank.out
 '
 test_expect_success '2n4p pmix.srv.rank is set correctly' '
 	cat >pmix.srv.rank.exp <<-EOT &&
@@ -206,6 +266,18 @@ test_expect_success '2n4p pmix.job.napps is set correctly' '
 		${GETKEY} --proc=* --label-io pmix.job.napps \
 			| sort -n >pmix.job.napps.out &&
 	test_cmp pmix.job.napps.exp pmix.job.napps.out
+'
+test_expect_success '2n3p pmix.nrank is set correctly' '
+	cat >2n3p.pmix.nrank.exp <<-EOT &&
+	0: 0
+	1: 1
+	2: 0
+	EOT
+	run_timeout 30 flux mini run -N2 -n3 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --label-io pmix.nrank \
+			| sort -n >2n3p.pmix.nrank.out &&
+	test_cmp 2n3p.pmix.nrank.exp 2n3p.pmix.nrank.out
 '
 test_expect_success '2n4p pmix.nrank is set correctly' '
 	cat >pmix.nrank.exp <<-EOT &&

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -122,6 +122,13 @@ test_expect_success '2n2p barrier with procs explictly set fails' '
 
 # Try a larger size for fun
 
+test_expect_success '2n3p barrier works' '
+	run_timeout 30 flux mini run -N2 -n3 \
+		-overbose=2 \
+		-ouserrc=$(pwd)/rc.lua \
+		${BARRIER}
+'
+
 test_expect_success '2n4p barrier works' '
 	run_timeout 30 flux mini run -N2 -n4 \
 		-overbose=2 \

--- a/t/t0004-bizcard.t
+++ b/t/t0004-bizcard.t
@@ -33,6 +33,13 @@ test_expect_success '2n2p bizcard exchange works' '
                ${BIZCARD} 1
 '
 
+test_expect_success '2n3p bizcard exchange works' '
+       run_timeout 30 flux mini run -N2 -n3 \
+	       -overbose=2 \
+               -ouserrc=$(pwd)/rc.lua \
+               ${BIZCARD} 1
+'
+
 test_expect_success '2n4p bizcard exchange works' '
        run_timeout 30 flux mini run -N2 -n4 \
                -ouserrc=$(pwd)/rc.lua \

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -13,6 +13,7 @@ test_under_flux 2
 test_expect_success 'create rc.lua script' "
 	cat >rc.lua <<-EOT
 	plugin.load (\"$PLUGINPATH/pmix.so\")
+	shell.setenv (\"OMPI_MCA_btl_tcp_if_include\", \"lo\")
 	EOT
 "
 
@@ -43,6 +44,21 @@ test_expect_success '2n2p ompi hello' '
 	run_timeout 30 flux mini run -N2 -n2 \
 		-ouserrc=$(pwd)/rc.lua \
 		-ompi=openmpi@5 \
+		${MPI_HELLO}
+'
+
+# Useful debugging runes:
+# --env=PMIX_MCA_pmix_client_fence_verbose=100 \
+# --env=OMPI_MCA_shmem_base_verbose=100 \
+# --env=OMPI_MCA_btl_base_verbose=100 \
+# --env=OMPI_MCA_btl_tcp_if_exclude=docker0,lo \
+
+# see issue #27
+test_expect_success '2n3p ompi hello doesnt hang' '
+	run_timeout 60 flux mini run -N2 -n3 \
+		-ouserrc=$(pwd)/rc.lua \
+		-ompi=openmpi@5 \
+		-overbose=2 \
 		${MPI_HELLO}
 '
 


### PR DESCRIPTION
I'm not sure this is the right solution to #27 but here it is for now.

The main "fix" is just to set `OMPI_MCA_btl_tcp_if_include=lo` in the test environment so that ompi ranks that are on different shells, but the same node don't get confused trying to find a working interface to communicate with tcp.

There's also a memory leak I happened across in the fence code, and some fence trace output improvement.

Finally some test expansion for the n2p3 case that is of dubious value (but I figured didn't hurt to leave in).