### PR TITLE
set pmix.jobid

### DIFF
--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -207,6 +207,7 @@ static int px_init (flux_plugin_t *p,
         return -1;
 
     if (!(iv = infovec_create ())
+        || infovec_set_str (iv, PMIX_JOBID, px->nspace) < 0
         || set_lpeers (iv, PMIX_LOCAL_PEERS, shell) < 0
         || set_node_map (iv, PMIX_NODE_MAP, shell) < 0
         || set_proc_map (iv, PMIX_PROC_MAP, shell) < 0

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -314,5 +314,10 @@ test_expect_success '2n4p pmix.max.size is set correctly' '
 			| sort -n >pmix.max.size.out &&
 	test_cmp pmix.max.size.exp pmix.max.size.out
 '
+test_expect_success '2n4p pmix.jobid is set' '
+	run_timeout 30 flux mini run -N2 -n4 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --proc=* --label-io pmix.jobid
+'
 
 test_done

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -301,5 +301,18 @@ test_expect_success '1n1p pmix.tdir.rmclean is true' '
 		${GETKEY} --proc=* pmix.tdir.rmclean >pmix.tdir.rmclean.out &&
 	test_cmp pmix.tdir.rmclean.exp pmix.tdir.rmclean.out
 '
+test_expect_success '2n4p pmix.max.size is set correctly' '
+	cat >pmix.max.size.exp <<-EOT &&
+	0: 4
+	1: 4
+	2: 4
+	3: 4
+	EOT
+	run_timeout 30 flux mini run -N2 -n4 \
+		-ouserrc=$(pwd)/rc.lua \
+		${GETKEY} --proc=* --label-io pmix.max.size \
+			| sort -n >pmix.max.size.out &&
+	test_cmp pmix.max.size.exp pmix.max.size.out
+'
 
 test_done


### PR DESCRIPTION
Set `pmix.jobid` to the f58-encoded flux jobid, in case it might be used at some point.

Plus a tiny bit of extra testing