### PR TITLE
testsuite: add pingpong test

### DIFF
--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -21,7 +21,8 @@ check_PROGRAMS = \
 	notify \
 	mpi_hello \
 	mpi_version \
-	mpi_abort
+	mpi_abort \
+	mpi_pingpong
 
 check_LTLIBRARIES = libtestutil.la
 
@@ -64,3 +65,6 @@ mpi_version_LDADD = $(test_ldadd)
 
 mpi_abort_SOURCES = mpi_abort.c
 mpi_abort_LDADD = $(test_ldadd)
+
+mpi_pingpong_SOURCES = mpi_pingpong.c
+mpi_pingpong_LDADD = $(test_ldadd)

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -6,7 +6,11 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir)
+	-I$(top_srcdir) \
+	$(FLUX_OPTPARSE_CFLAGS) \
+	$(FLUX_IDSET_CFLAGS) \
+	$(OMPI_CFLAGS) \
+	$(PMIX_CFLAGS)
 
 check_PROGRAMS = \
 	barrier \
@@ -28,47 +32,35 @@ libtestutil_la_SOURCES = \
 	monotime.h
 
 test_ldadd = \
-	$(builddir)/libtestutil.la
+	$(builddir)/libtestutil.la \
+	$(FLUX_OPTPARSE_LIBS) \
+	$(FLUX_IDSET_LIBS) \
+	$(OMPI_LIBS) \
+	$(PMIX_LIBS)
 
 barrier_SOURCES = barrier.c
-barrier_CPPFLAGS = \
-	$(AM_CPPFLAGS) \
-	$(PMIX_CFLAGS) \
-	$(FLUX_OPTPARSE_CFLAGS) \
-	$(FLUX_IDSET_CFLAGS)
-barrier_LDADD = $(test_ldadd) \
-	$(PMIX_LIBS) \
-	$(FLUX_OPTPARSE_LIBS) \
-	$(FLUX_IDSET_LIBS)
+barrier_LDADD = $(test_ldadd)
 
 bizcard_SOURCES = bizcard.c
-bizcard_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)
-bizcard_LDADD = $(test_ldadd) $(PMIX_LIBS)
+bizcard_LDADD = $(test_ldadd)
 
 version_SOURCES = version.c
-version_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS)
-version_LDADD = $(test_ldadd) $(PMIX_LIBS)
+version_LDADD = $(test_ldadd)
 
 getkey_SOURCES = getkey.c
-getkey_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
-getkey_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
+getkey_LDADD = $(test_ldadd)
 
 abort_SOURCES = abort.c
-abort_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
-abort_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
+abort_LDADD = $(test_ldadd)
 
 notify_SOURCES = notify.c
-notify_CPPFLAGS = $(AM_CPPFLAGS) $(PMIX_CFLAGS) $(FLUX_OPTPARSE_CFLAGS)
-notify_LDADD = $(test_ldadd) $(PMIX_LIBS) $(FLUX_OPTPARSE_LIBS)
+notify_LDADD = $(test_ldadd)
 
 mpi_hello_SOURCES = mpi_hello.c
-mpi_hello_CPPFLAGS = $(AM_CPPFLAGS) $(OMPI_CFLAGS)
-mpi_hello_LDADD = $(test_ldadd) $(OMPI_LIBS)
+mpi_hello_LDADD = $(test_ldadd)
 
 mpi_version_SOURCES = mpi_version.c
-mpi_version_CPPFLAGS = $(AM_CPPFLAGS) $(OMPI_CFLAGS)
-mpi_version_LDADD = $(test_ldadd) $(OMPI_LIBS)
+mpi_version_LDADD = $(test_ldadd)
 
 mpi_abort_SOURCES = mpi_abort.c
-mpi_abort_CPPFLAGS = $(AM_CPPFLAGS) $(OMPI_CFLAGS)
-mpi_abort_LDADD = $(test_ldadd) $(OMPI_LIBS)
+mpi_abort_LDADD = $(test_ldadd)

--- a/t/src/mpi_pingpong.c
+++ b/t/src/mpi_pingpong.c
@@ -1,0 +1,101 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <mpi.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <time.h>
+#include <flux/optparse.h>
+
+#include "log.h"
+
+
+#include "log.h"
+
+const char *opt_usage = "[OPTIONS]";
+
+static struct optparse_option opts[] = {
+    { .name = "count", .has_arg = 1, .arginfo = "TEXT",
+      .usage = "number of ping pong round trips (default 1)",
+    },
+    OPTPARSE_TABLE_END,
+};
+
+
+int main (int argc, char *argv[])
+{
+    optparse_t *p;
+    int optindex;
+    int rank = -1;
+    int size;
+    char name[32];
+    int count;
+    int limit;
+    int peer_rank;
+
+    MPI_Init (&argc, &argv);
+    MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+    MPI_Comm_size (MPI_COMM_WORLD, &size);
+
+    if (!(p = optparse_create ("mpi_pingpong"))
+        || optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS
+        || optparse_set (p, OPTPARSE_USAGE, opt_usage) != OPTPARSE_SUCCESS)
+        log_msg_exit ("error setting up option parsing");
+    if ((optindex = optparse_parse_args (p, argc, argv)) < 0)
+        return 1;
+    if (optindex != argc) {
+        optparse_print_usage (p);
+        return 1;
+    }
+    limit = optparse_get_int (p, "count", 1);
+    if (limit < 1)
+        log_msg_exit ("count must be at least 1");
+
+    snprintf (name, sizeof (name), "%d", rank);
+    log_init (name);
+
+    if (size != 2)
+        log_msg_exit ("this program requires exactly 2 processes");
+
+    if (rank == 0)
+        log_msg ("MPI_Init completed");
+
+
+    MPI_Barrier (MPI_COMM_WORLD);
+    if (rank == 0)
+        log_msg ("MPI_Barrier completed");
+
+    peer_rank = (rank + 1) % 2;
+    for (count = 0; count < limit*2; count++) {
+        if (count % 2 == rank)
+            MPI_Send (&count, 1, MPI_INT, peer_rank, 0, MPI_COMM_WORLD);
+        else {
+            int ncount;
+            MPI_Recv (&ncount, 1, MPI_INT, peer_rank, 0, MPI_COMM_WORLD,
+                      MPI_STATUS_IGNORE);
+            if (ncount != count)
+                log_msg_exit ("bad data received (%d != %d)", ncount, count);
+        }
+        if (rank == 0 && count % 2 == 1)
+            log_msg ("pingpong seq=%d completed", count / 2);
+    }
+
+    MPI_Finalize ();
+    if (rank == 0)
+        log_msg ("MPI_Finalize completed");
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab
+

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -7,6 +7,7 @@ PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
 . `dirname $0`/sharness.sh
 
 MPI_HELLO=${FLUX_BUILD_DIR}/t/src/mpi_hello
+MPI_PINGPONG=${FLUX_BUILD_DIR}/t/src/mpi_pingpong
 
 test_under_flux 2
 
@@ -69,6 +70,19 @@ test_expect_success '2n4p ompi hello reports no system call errors' '
                 -ompi=openmpi@5 \
                 ${MPI_HELLO} 2>2n4p_hello.err &&
         test_must_fail grep "System call:" 2n4p_hello.err
+'
+
+test_expect_success '1n2p ompi pingpong works' '
+        run_timeout 30 flux mini run -N1 -n2 \
+                -ouserrc=$(pwd)/rc.lua \
+                -ompi=openmpi@5 \
+                ${MPI_PINGPONG}
+'
+test_expect_success '2n2p ompi pingpong works' '
+        run_timeout 30 flux mini run -N2 -n2 \
+                -ouserrc=$(pwd)/rc.lua \
+                -ompi=openmpi@5 \
+                ${MPI_PINGPONG}
 '
 
 test_done


### PR DESCRIPTION
I was a little concerned that maybe something basic was not working because of #36 and wanted to take a smaller step between the "hello world" tests in `t1000-ompi-basic.t` and `t1001-osu-benchmarks.t` so this PR adds a little test to the former that moves a bit of data between two ranks in 1np2 and 2np2 configs.

Ultimately this didn't provide any useful clues to #36 but it still may not be a bad thing to do.