### PR TITLE
plugin: call notify_destroy() early

### DIFF
--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -49,9 +49,9 @@ static void px_destroy (struct px *px)
     if (px) {
         int rc;
         int saved_errno = errno;
+        notify_destroy (px->notify);
         if ((rc = PMIx_server_finalize ()) != PMIX_SUCCESS)
             shell_warn ("PMIx_server_finalize: %s", PMIx_Error_string (rc));
-        notify_destroy (px->notify);
         abort_destroy (px->abort);
         fence_destroy (px->fence);
         dmodex_destroy (px->dmodex);

--- a/src/shell/plugins/notify.h
+++ b/src/shell/plugins/notify.h
@@ -15,7 +15,8 @@
 #include <pmix_server.h>
 #include "interthread.h"
 
-/* N.B. notify_create() must be called after PMIx_server_init().
+/* N.B. notify_create() must be called after PMIx_server_init()
+ * and notify_destroy() must be called before PMIx_server_finalize().
  */
 struct notify *notify_create (flux_shell_t *shell, struct interthread *it);
 void notify_destroy (struct notify *notify);


### PR DESCRIPTION
Problem: plugin hangs in px_destroy() in RHEL 7 / spack
environment.

notify_destroy() is being called after PMIx_server_finalize(),
but it calls PMIx_Deregister_event_handler() which is probably
a "thread shifted" call.

Change the ordering of px_destroy() so that notify_destroy()
is called before PMIx_server_finalize().

Fixes #44