### PR TITLE
build: fix build with gcc 4.x, add centos7 to ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
           ompi_branch: "v5.0.x"
           coverage: false
           env: {}
-        - name: "focal - ompi v5.0.x, chain_lint"
-          image: "focal"
+        - name: "centos7 - ompi v5.0.x, chain_lint"
+          image: "centos7"
           ompi_branch: "v5.0.x"
           coverage: false
           env:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - base=main
       - status-success="validate commits"
       - status-success="focal - ompi v5.0.x"
-      - status-success="focal - ompi v5.0.x, chain_lint"
+      - status-success="centos7 - ompi v5.0.x, chain_lint"
       - status-success="centos8 - ompi v5.0.x, distcheck"
       - status-success="coverage"
       - status-success="fedora34 - ompi v5.0.x"

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -192,10 +192,12 @@ static int px_init (flux_plugin_t *p,
     strncpy (info[0].key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_STRING;
     info[0].value.data.string = (char *)px->job_tmpdir;
+    info[0].flags = 0;
 
     strncpy (info[1].key, PMIX_SERVER_RANK, PMIX_MAX_KEYLEN);
     info[1].value.type = PMIX_PROC_RANK;
     info[1].value.data.rank = px->shell_rank;
+    info[1].flags = 0;
 
     if ((rc = PMIx_server_init (&server_callbacks, info, 2)) != PMIX_SUCCESS) {
         shell_warn ("PMIx_server_init: %s", PMIx_Error_string (rc));

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -135,7 +135,7 @@ static int px_init (flux_plugin_t *p,
     flux_shell_t *shell = flux_plugin_get_shell (p);
     struct px *px;
     int rc;
-    pmix_info_t info[2] = { 0 };
+    pmix_info_t info[2];
     struct infovec *iv;
 
     if (!(px = calloc (1, sizeof (*px)))
@@ -244,7 +244,7 @@ static int px_task_init (flux_plugin_t *p,
     struct px *px;
     flux_shell_task_t *task;
     flux_cmd_t *cmd;
-    pmix_proc_t proc = { 0 };
+    pmix_proc_t proc;
     char **env = NULL;
     int rank;
     int rc;

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -1,0 +1,60 @@
+FROM fluxrm/flux-core:bionic
+
+ARG USER=fluxuser
+ARG UID=1000
+ARG OMPI_BRANCH=v5.0.x
+ARG OPENPMIX_BRANCH=v4.1.1rc2
+
+RUN \
+ if test "$USER" != "fluxuser"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo adduser $USER sudo ; \
+ fi
+
+# ompi can't coexist with mpich
+RUN sudo apt remove -yy mpich \
+ && sudo apt clean
+
+# install ompi prereqs
+RUN sudo apt-get update \
+ && sudo apt-get -qq install -y --no-install-recommends \
+    libevent-dev \
+    flex \
+    openssh-client \
+ && sudo apt clean \
+ && sudo rm -rf /var/lib/apt/lists/*
+
+# build/install openpmix
+RUN cd /tmp \
+ && git clone -b ${OPENPMIX_BRANCH} \
+      --recursive --depth=1 https://github.com/openpmix/openpmix \
+ && cd openpmix \
+ && git branch \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --enable-debug \
+ && make -j $(nproc) \
+ && sudo make install \
+ && cd .. \
+ && rm -rf openpmix
+
+# build/install ompi
+RUN cd /tmp \
+ && git clone -b ${OMPI_BRANCH} \
+      --recursive --depth=1 https://github.com/open-mpi/ompi \
+ && cd ompi \
+ && git branch \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --disable-man-pages --enable-debug --enable-mem-debug \
+      --with-pmix=external --with-libevent \
+ && make -j $(nproc) \
+ && sudo make install \
+ && cd .. \
+ && rm -rf ompi
+
+USER $USER
+WORKDIR /home/$USER
+

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -1,0 +1,59 @@
+FROM fluxrm/flux-core:centos7
+
+ARG USER=fluxuser
+ARG UID=1000
+ARG OMPI_BRANCH=v5.0.x
+ARG OPENPMIX_BRANCH=v4.1.1rc2
+
+RUN \
+ if test "$USER" != "fluxuser"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER \
+   && sudo usermod -G wheel fluxuser ; \
+ fi
+
+# ompi incompatible with mpich
+RUN sudo yum -y remove mpich mpich-devel
+
+# install ompi prereqs
+RUN sudo yum -y update \
+ && sudo yum -y install \
+    flex \
+    libevent-devel \
+    zlib-devel \
+ && sudo yum clean all
+
+ # build/install openpmix
+RUN cd /tmp \
+ && git clone -b ${OPENPMIX_BRANCH} \
+      --recursive --depth=1 https://github.com/openpmix/openpmix \
+ && cd openpmix \
+ && git branch \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --enable-debug \
+ && make -j $(nproc) \
+ && sudo make install \
+ && cd .. \
+ && rm -rf openpmix
+
+# build/install ompi
+RUN cd /tmp \
+ && git clone -b ${OMPI_BRANCH} \
+      --recursive --depth=1 https://github.com/open-mpi/ompi \
+ && cd ompi \
+ && git branch \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --disable-man-pages --enable-debug --enable-mem-debug \
+      --with-pmix=external --with-libevent \
+ && make -j $(nproc) \
+ && sudo make install \
+ && cd .. \
+ && rm -rf ompi
+
+USER $USER
+WORKDIR /home/$USER
+

--- a/t/src/barrier.c
+++ b/t/src/barrier.c
@@ -207,7 +207,7 @@ int main (int argc, char **argv)
      */
     struct timespec t;
     monotime (&t);
-    pmix_info_t info[8] = { 0 };
+    pmix_info_t info[8];
     pmix_proc_t *procs = NULL;
     size_t ninfo = parse_info_opts (p, info, sizeof (info) / sizeof (info[0]));
     size_t nprocs = parse_procs_opt (p, &self, &procs);

--- a/t/src/getkey.c
+++ b/t/src/getkey.c
@@ -79,7 +79,7 @@ int main (int argc, char **argv)
     optparse_t *p;
     int optindex;
     pmix_proc_t self;
-    pmix_proc_t proc = { 0 };
+    pmix_proc_t proc;
     const char *key;
     int rc;
     int rank;

--- a/t/src/notify.c
+++ b/t/src/notify.c
@@ -39,7 +39,7 @@ int main (int argc, char **argv)
     pmix_proc_t self;
     int event_status;
     const char *event_message;
-    pmix_info_t info[1] = { 0 };
+    pmix_info_t info[1];
     size_t ninfo = 0;
     int rc;
 

--- a/t/src/notify.c
+++ b/t/src/notify.c
@@ -88,6 +88,7 @@ int main (int argc, char **argv)
         strncpy (info[ninfo].key, PMIX_EVENT_TEXT_MESSAGE, PMIX_MAX_KEYLEN);
         info[ninfo].value.type = PMIX_STRING;
         info[ninfo].value.data.string = (char *)event_message;
+        info[ninfo].flags = 0;
         ninfo++;
     }
     if ((rc = PMIx_Notify_event (event_status,


### PR DESCRIPTION
This PR fixes the compilation problem described in #47, and adds a gcc 4.x build via a new centos7 builder in CI.

Edit: This PR also adds a bionic Dockerfile, but does not use it in CI due to an outstanding segfault on that platform. (Will open issue)

