### PR TITLE
mergify: replace deprecated strict merge strategy

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,22 +1,27 @@
+queue_rules:
+  - name: default
+    conditions:
+      - base=main
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - -title~=^\[*[Ww][Ii][Pp]
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+
 pull_request_rules:
   - name: rebase and merge when passing all checks
     conditions:
       - base=main
-      - status-success="validate commits"
-      - status-success="focal - ompi v5.0.x"
-      - status-success="centos7 - ompi v5.0.x, chain_lint"
-      - status-success="centos8 - ompi v5.0.x, distcheck"
-      - status-success="coverage"
-      - status-success="fedora34 - ompi v5.0.x"
       - label="merge-when-passing"
       - label!="work-in-progress"
+      - -title~=^\[*[Ww][Ii][Pp]
       - "approved-reviews-by=@flux-framework/core"
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
-      - -title~=^\[*[Ww][Ii][Pp]
     actions:
-      merge:
+      queue:
+        name: default
         method: merge
-        strict: smart
-        strict_method: rebase
+        update_method: rebase
 


### PR DESCRIPTION
Problem: Mergify has deprecated strict mode merge in favor of
using merge queues.

Update the mergify config to use a default merge queue with a rebase
and merge strategy which seems to match the strict behavior from before.

Drop the status checks from the mergify.yml, since these largely seem
to be redundant with GitHub branch protections. (Mergify will not merge
until all branch protections are met.)