### PR TITLE
use strlcpy instead of strncpy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = \
 	src/common/libtap \
 	src/common/libccan \
+	src/common/libutil \
 	src/shell/plugins \
 	src/shell/lua.d \
 	t

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,6 @@ coverage:
  - ".*/test/.*"
  - ".*/common/libtap/.*"
  - ".*/common/libccan/.*"
+ - ".*/common/libutil/strlcpy.[ch]"
  - "/usr/include/.*"
  - "/usr/lib/.*"

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,7 @@ AC_CONFIG_FILES( \
   Makefile \
   src/common/libtap/Makefile \
   src/common/libccan/Makefile \
+  src/common/libutil/Makefile \
   src/shell/plugins/Makefile \
   src/shell/lua.d/Makefile \
   t/Makefile \

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -1,0 +1,13 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS =
+
+noinst_LTLIBRARIES = libutil.la
+libutil_la_SOURCES = \
+	strlcpy.c \
+	strlcpy.h

--- a/src/common/libutil/strlcpy.c
+++ b/src/common/libutil/strlcpy.c
@@ -1,0 +1,55 @@
+/*	$OpenBSD: strlcpy.c,v 1.8 2003/06/17 21:56:24 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char *rcsid = "$OpenBSD: strlcpy.c,v 1.8 2003/06/17 21:56:24 millert Exp $";
+#endif /* LIBC_SCCS and not lint */
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy src to string dst of size siz.  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz == 0).
+ * Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+size_t
+strlcpy(char *dst, const char *src, size_t siz)
+{
+	register char *d = dst;
+	register const char *s = src;
+	register size_t n = siz;
+
+	/* Copy as many bytes as will fit */
+	if (n != 0 && --n != 0) {
+		do {
+			if ((*d++ = *s++) == 0)
+				break;
+		} while (--n != 0);
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src */
+	if (n == 0) {
+		if (siz != 0)
+			*d = '\0';		/* NUL-terminate dst */
+		while (*s++)
+			;
+	}
+
+	return(s - src - 1);	/* count does not include NUL */
+}

--- a/src/common/libutil/strlcpy.h
+++ b/src/common/libutil/strlcpy.h
@@ -1,0 +1,12 @@
+#if HAVE_CONFIG_H
+#  include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#if !HAVE_STRLCPY
+size_t strlcpy(char *dst, const char *src, size_t siz);
+/*
+ *  Copy src to string dst of size siz.  At most siz-1 characters
+ *    will be copied.  Always NUL terminates (unless siz == 0).
+ *  Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+#endif /* !HAVE_STRLCPY */

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -46,7 +46,8 @@ pmix_la_LIBADD = \
 	$(FLUX_IDSET_LIBS) \
 	$(FLUX_HOSTLIST_LIBS) \
 	$(JANSSON_LIBS) \
-	$(top_builddir)/src/common/libccan/libccan.la
+	$(top_builddir)/src/common/libccan/libccan.la \
+	$(top_builddir)/src/common/libutil/libutil.la
 pmix_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(fluxplugin_ldflags) \
@@ -58,7 +59,8 @@ TESTS = \
 
 test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(top_builddir)/src/common/libccan/libccan.la
+	$(top_builddir)/src/common/libccan/libccan.la \
+	$(top_builddir)/src/common/libutil/libutil.la
 
 test_ldflags = \
 	-no-install

--- a/src/shell/plugins/codec.c
+++ b/src/shell/plugins/codec.c
@@ -18,6 +18,7 @@
 #include <pmix_server.h>
 
 #include "src/common/libccan/ccan/base64/base64.h"
+#include "src/common/libutil/strlcpy.h"
 
 #include "codec.h"
 
@@ -119,7 +120,7 @@ int codec_proc_decode (json_t *o, pmix_proc_t *proc)
                      "rank", &rank) < 0)
         return -1;
     proc->rank = rank;
-    strncpy (proc->nspace, nspace, PMIX_MAX_NSLEN);
+    strlcpy (proc->nspace, nspace, sizeof (proc->nspace));
     proc->nspace[PMIX_MAX_NSLEN] = '\0';
     return 0;
 }
@@ -399,7 +400,7 @@ int codec_info_decode (json_t *o, pmix_info_t *info)
         return -1;
     if (codec_value_decode (xvalue, &info->value) < 0) // allocs mem
         return -1;
-    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    strlcpy (info->key, key, sizeof (info->key));
     info->key[PMIX_MAX_KEYLEN] = '\0';
     return 0;
 }

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -17,6 +17,8 @@
 #include <errno.h>
 #include <pmix.h>
 
+#include "src/common/libutil/strlcpy.h"
+
 #include "infovec.h"
 
 #define INFOVEC_CHUNK 8
@@ -52,7 +54,7 @@ int infovec_set_str_new (struct infovec *iv, const char *key, char *val)
     }
     if (!(info = alloc_slot (iv)))
         return -1;
-    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    strlcpy (info->key, key, sizeof (info->key));
     info->value.type = PMIX_STRING;
     info->value.data.string = val;
     return 0;
@@ -86,7 +88,7 @@ int infovec_set_u32 (struct infovec *iv, const char *key, uint32_t value)
     }
     if (!(info = alloc_slot (iv)))
         return -1;
-    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    strlcpy (info->key, key, sizeof (info->key));
     info->value.type = PMIX_UINT32;
     info->value.data.uint32 = value;
     return 0;
@@ -102,7 +104,7 @@ int infovec_set_bool (struct infovec *iv, const char *key, bool value)
     }
     if (!(info = alloc_slot (iv)))
         return -1;
-    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    strlcpy (info->key, key, sizeof (info->key));
     info->value.type = PMIX_BOOL;
     info->value.data.flag = value;
     return 0;
@@ -120,7 +122,7 @@ int infovec_set_rank (struct infovec *iv,
     }
     if (!(info = alloc_slot (iv)))
         return -1;
-    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    strlcpy (info->key, key, sizeof (info->key));
     info->value.type = PMIX_PROC_RANK;
     info->value.data.rank = value;
     return 0;

--- a/src/shell/plugins/interthread.c
+++ b/src/shell/plugins/interthread.c
@@ -17,6 +17,8 @@
 #include <jansson.h>
 #include <flux/core.h>
 
+#include "src/common/libutil/strlcpy.h"
+
 #include "interthread.h"
 
 #define MAX_HANDLERS 32
@@ -48,7 +50,7 @@ int interthread_register (struct interthread *it,
         return -1;
     }
     handler = &it->handlers[it->handler_count++];
-    strncpy (handler->topic, topic, sizeof (handler->topic) - 1);
+    strlcpy (handler->topic, topic, sizeof (handler->topic));
     handler->cb = cb;
     handler->arg = arg;
     return 0;

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -19,6 +19,8 @@
 #include <pmix_server.h>
 #include <pmix.h>
 
+#include "src/common/libutil/strlcpy.h"
+
 #include "infovec.h"
 #include "maps.h"
 #include "interthread.h"
@@ -189,12 +191,12 @@ static int px_init (flux_plugin_t *p,
         return -1;
     server_callbacks.direct_modex = dmodex_server_cb;
 
-    strncpy (info[0].key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN);
+    strlcpy (info[0].key, PMIX_SERVER_TMPDIR, sizeof (info[0].key));
     info[0].value.type = PMIX_STRING;
     info[0].value.data.string = (char *)px->job_tmpdir;
     info[0].flags = 0;
 
-    strncpy (info[1].key, PMIX_SERVER_RANK, PMIX_MAX_KEYLEN);
+    strlcpy (info[1].key, PMIX_SERVER_RANK, sizeof (info[1].key));
     info[1].value.type = PMIX_PROC_RANK;
     info[1].value.data.rank = px->shell_rank;
     info[1].flags = 0;

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -34,6 +34,7 @@ libtestutil_la_SOURCES = \
 
 test_ldadd = \
 	$(builddir)/libtestutil.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(FLUX_OPTPARSE_LIBS) \
 	$(FLUX_IDSET_LIBS) \
 	$(OMPI_LIBS) \

--- a/t/src/abort.c
+++ b/t/src/abort.c
@@ -18,6 +18,8 @@
 #include <stdio.h>
 #include <flux/optparse.h>
 
+#include "src/common/libutil/strlcpy.h"
+
 #include "log.h"
 
 const char *opt_usage = "[OPTIONS]";
@@ -75,8 +77,7 @@ int main (int argc, char **argv)
      */
     pmix_proc_t proc;
     pmix_value_t *valp;
-    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
-    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    strlcpy (proc.nspace, self.nspace, sizeof (proc.nspace));
     proc.rank = PMIX_RANK_WILDCARD;
     if ((rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &valp)) != PMIX_SUCCESS)
         log_msg_exit ("PMIx_Get %s: %s", PMIX_JOB_SIZE, PMIx_Error_string (rc));

--- a/t/src/barrier.c
+++ b/t/src/barrier.c
@@ -19,6 +19,8 @@
 #include <flux/optparse.h>
 #include <flux/idset.h>
 
+#include "src/common/libutil/strlcpy.h"
+
 #include "log.h"
 #include "monotime.h"
 
@@ -52,7 +54,7 @@ void set_info_bool (pmix_info_t *info,
     bool value = true;
     if (!strcmp (optarg, "false"))
         value = false;
-    strncpy (info->key, name, PMIX_MAX_KEYLEN);
+    strlcpy (info->key, name, sizeof (info->key));
     info->flags = flags;
     info->value.type = PMIX_BOOL;
     info->value.data.flag = value;
@@ -63,7 +65,7 @@ void set_info_int (pmix_info_t *info,
                    int flags,
                    int optarg)
 {
-    strncpy (info->key, name, PMIX_MAX_KEYLEN);
+    strlcpy (info->key, name, sizeof (info->key));
     info->flags = flags;
     info->value.type = PMIX_INT;
     info->value.data.flag = optarg;
@@ -193,8 +195,7 @@ int main (int argc, char **argv)
      */
     pmix_proc_t proc;
     pmix_value_t *valp;
-    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
-    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    strlcpy (proc.nspace, self.nspace, sizeof (proc.nspace));
     proc.rank = PMIX_RANK_WILDCARD;
     if ((rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &valp)) != PMIX_SUCCESS)
         log_msg_exit ("PMIx_Get %s: %s", PMIX_JOB_SIZE, PMIx_Error_string (rc));

--- a/t/src/bizcard.c
+++ b/t/src/bizcard.c
@@ -18,6 +18,8 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include "src/common/libutil/strlcpy.h"
+
 #include "log.h"
 #include "monotime.h"
 
@@ -48,8 +50,7 @@ int main (int argc, char **argv)
 
     /* Get the size
      */
-    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
-    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    strlcpy (proc.nspace, self.nspace, sizeof (proc.nspace));
     proc.rank = PMIX_RANK_WILDCARD;
     if ((rc = PMIx_Get (&proc,
                         PMIX_JOB_SIZE,
@@ -130,8 +131,7 @@ int main (int argc, char **argv)
 
     /* Fence
      */
-    strncpy (info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-    info.key[PMIX_MAX_KEYLEN] = '\0';
+    strlcpy (info.key, PMIX_COLLECT_DATA, sizeof (info.key));
     info.value.type = PMIX_BOOL;
     info.value.data.flag = true;
 
@@ -148,8 +148,7 @@ int main (int argc, char **argv)
             pmix_proc_t proc;
             pmix_value_t *valp;
 
-            strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
-            proc.nspace[PMIX_MAX_NSLEN] = '\0';
+            strlcpy (proc.nspace, self.nspace, sizeof (proc.nspace));
             errno = 0;
             proc.rank = strtoul (argv[optindex], NULL, 10);
             if (errno != 0)

--- a/t/src/notify.c
+++ b/t/src/notify.c
@@ -18,6 +18,8 @@
 #include <stdio.h>
 #include <flux/optparse.h>
 
+#include "src/common/libutil/strlcpy.h"
+
 #include "log.h"
 
 const char *opt_usage = "[OPTIONS]";
@@ -72,8 +74,7 @@ int main (int argc, char **argv)
      */
     pmix_proc_t proc;
     pmix_value_t *valp;
-    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
-    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    strlcpy (proc.nspace, self.nspace, sizeof (proc.nspace));
     proc.rank = PMIX_RANK_WILDCARD;
     if ((rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &valp)) != PMIX_SUCCESS)
         log_msg_exit ("PMIx_Get %s: %s", PMIX_JOB_SIZE, PMIx_Error_string (rc));
@@ -85,7 +86,9 @@ int main (int argc, char **argv)
     /* Add any info options
      */
     if (event_message) {
-        strncpy (info[ninfo].key, PMIX_EVENT_TEXT_MESSAGE, PMIX_MAX_KEYLEN);
+        strlcpy (info[ninfo].key,
+                 PMIX_EVENT_TEXT_MESSAGE,
+                 sizeof (info[ninfo].key));
         info[ninfo].value.type = PMIX_STRING;
         info[ninfo].value.data.string = (char *)event_message;
         info[ninfo].flags = 0;


### PR DESCRIPTION
The use of `strncpy()` is error prone, so bring in `strlcpy()`.  There is actually at least one place where dropping the static initializer for a `pmix_info_t` struct created an unsafe (though unlikely) situation.

Anyway this is better hygiene.