### PR TITLE
update openpmix and ompi versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,32 +22,32 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: "focal - ompi v5.0.x"
+        - name: "focal - ompi v5.0.0rc9"
           image: "focal"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc9"
           coverage: false
           env: {}
-        - name: "centos7 - ompi v5.0.x, chain_lint"
+        - name: "centos7 - ompi v5.0.0rc9, chain_lint"
           image: "centos7"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc9"
           coverage: false
           env:
             chain_lint: t
-        - name: "centos8 - ompi v5.0.x, distcheck"
+        - name: "centos8 - ompi v5.0.0rc9, distcheck"
           image: "centos8"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc9"
           coverage: false
           env:
             DISTCHECK: t
         - name: "coverage"
           image: "focal"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc9"
           coverage: true
           env:
             COVERAGE: t
-        - name: "fedora34 - ompi v5.0.x"
+        - name: "fedora34 - ompi v5.0.0rc9"
           image: "fedora34"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc9"
           coverage: false
           env: {}
         - name: "focal - ompi v4.1.x"

--- a/config/ax_flux_core.m4
+++ b/config/ax_flux_core.m4
@@ -28,6 +28,8 @@
 #   - FLUX_OPTPARSE_CFLAGS libflux-optparse CFLAGS
 #   - FLUX_HOSTLIST_LIBS   libflux-hostlist LIBS
 #   - FLUX_HOSTLIST_CFLAGS libflux-hostlist CFLAGS
+#   - FLUX_TASKMAP_LIBS    libflux-taskmap LIBS
+#   - FLUX_TASKMAP_CFLAGS  libflux-taskmap CFLAGS
 #
 # LICENSE
 #
@@ -49,7 +51,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH}
   export PKG_CONFIG_PATH
 
-  PKG_CHECK_MODULES([FLUX_CORE], [flux-core > 0.29.0],
+  PKG_CHECK_MODULES([FLUX_CORE], [flux-core >= 0.46.0],
     [
       FLUX_PREFIX=`pkg-config --variable=prefix flux-core`
       LIBFLUX_VERSION=`pkg-config --modversion flux-core`
@@ -79,6 +81,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CHECK_MODULES([FLUX_SCHEDUTIL], [flux-schedutil], [], [])
   PKG_CHECK_MODULES([FLUX_OPTPARSE], [flux-optparse], [], [])
   PKG_CHECK_MODULES([FLUX_HOSTLIST], [flux-hostlist], [], [])
+  PKG_CHECK_MODULES([FLUX_TASKMAP], [flux-taskmap], [], [])
 
   PKG_CONFIG_PATH=$saved_PKG_CONFIG_PATH
   export PKG_CONFIG_PATH

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -38,6 +38,7 @@ pmix_la_CPPFLAGS = \
 	$(FLUX_CORE_CFLAGS) \
 	$(FLUX_IDSET_CFLAGS) \
 	$(FLUX_HOSTLIST_CFLAGS) \
+	$(FLUX_TASKMAP_CFLAGS) \
 	$(PMIX_CFLAGS) \
 	$(JANSSON_CFLAGS)
 pmix_la_LIBADD = \
@@ -45,6 +46,7 @@ pmix_la_LIBADD = \
 	$(PMIX_LIBS) \
 	$(FLUX_IDSET_LIBS) \
 	$(FLUX_HOSTLIST_LIBS) \
+	$(FLUX_TASKMAP_LIBS) \
 	$(JANSSON_LIBS) \
 	$(top_builddir)/src/common/libccan/libccan.la \
 	$(top_builddir)/src/common/libutil/libutil.la

--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -112,22 +112,12 @@ static int parse_fence_attr (struct fence_call *fxcall, pmix_info_t *info)
             fxcall->collect = true;
         goto done;
     }
-    /* This attr is listed in the openpmix EXCEPTIONS as an
-     * experimental development feature and pops pops up when running
-     * osu benchmarks.  We don't know what to do with it, but let's
-     * tone down the warning to debug level to avoid alarming users.
-     */
-    else if (!strcmp (info->key, "pmix.loc.col.st")) {
-        shell_debug ("ignoring experimental %s fence attr: %s",
-                     required ? "required" : "optional",
-                     info->key);
-        goto done;
-    }
-    shell_warn ("unknown %s fence attr: %s",
-                required ? "required" : "optional",
-                info->key);
-    if (required)
+    if (required) {
+        shell_warn ("unknown required fence attr: %s", info->key);
         rc = PMIX_ERR_BAD_PARAM;
+    }
+    else
+        shell_debug ("ignoring optional fence attr: %s", info->key);
 done:
     return rc;
 type_error:

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -150,6 +150,7 @@ void infovec_destroy (struct infovec *iv)
                     break;
             }
         }
+        free (iv->info);
         free (iv);
         errno = saved_errno;
     }

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -128,6 +128,31 @@ int infovec_set_rank (struct infovec *iv,
     return 0;
 }
 
+int infovec_set_infovec_new (struct infovec *iv,
+                             const char *key,
+                             struct infovec *val)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strlcpy (info->key, key, sizeof (info->key));
+    info->value.type = PMIX_DATA_ARRAY;
+    if (!(info->value.data.darray = calloc (1, sizeof (pmix_data_array_t))))
+        return -1;
+    /* steal val->info and free val */
+    info->value.data.darray->type = PMIX_INFO;
+    info->value.data.darray->size = val->count;
+    info->value.data.darray->array = val->info;
+    free (val);
+
+    return 0;
+}
+
 int infovec_count (struct infovec *iv)
 {
     return iv->count;
@@ -138,19 +163,33 @@ pmix_info_t *infovec_info (struct infovec *iv)
     return iv->info;
 }
 
-void infovec_destroy (struct infovec *iv)
+static void destroy_info_array (pmix_info_t *info, int count)
 {
-    if (iv) {
-        int saved_errno = errno;
-        for (int i = 0; i < iv->count; i++) {
-            pmix_value_t *value = &iv->info[i].value;
+    if (info) {
+        for (int i = 0; i < count; i++) {
+            pmix_value_t *value = &info[i].value;
             switch (value->type) {
                 case PMIX_STRING:
                     free (value->data.string);
                     break;
+                case PMIX_DATA_ARRAY:
+                    if (value->data.darray) { // recurse
+                        destroy_info_array (value->data.darray->array,
+                                            value->data.darray->size);
+                        free (value->data.darray);
+                    }
+                    break;
             }
         }
-        free (iv->info);
+        free (info);
+    }
+}
+
+void infovec_destroy (struct infovec *iv)
+{
+    if (iv) {
+        int saved_errno = errno;
+        destroy_info_array (iv->info, iv->count);
         free (iv);
         errno = saved_errno;
     }

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -94,6 +94,22 @@ int infovec_set_u32 (struct infovec *iv, const char *key, uint32_t value)
     return 0;
 }
 
+int infovec_set_u16 (struct infovec *iv, const char *key, uint16_t value)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strlcpy (info->key, key, sizeof (info->key));
+    info->value.type = PMIX_UINT16;
+    info->value.data.uint16 = value;
+    return 0;
+}
+
 int infovec_set_bool (struct infovec *iv, const char *key, bool value)
 {
     pmix_info_t *info;

--- a/src/shell/plugins/infovec.h
+++ b/src/shell/plugins/infovec.h
@@ -21,6 +21,9 @@ int infovec_set_str (struct infovec *iv, const char *key, const char *str);
 int infovec_set_str_new (struct infovec *iv, const char *key, char *str);
 int infovec_set_bool (struct infovec *iv, const char *key, bool val);
 int infovec_set_rank (struct infovec *iv, const char *key, pmix_rank_t val);
+int infovec_set_infovec_new (struct infovec *iv,
+                             const char *key,
+                             struct infovec *val);
 
 int infovec_count (struct infovec *iv);
 pmix_info_t *infovec_info (struct infovec *iv);

--- a/src/shell/plugins/infovec.h
+++ b/src/shell/plugins/infovec.h
@@ -17,6 +17,7 @@ struct infovec *infovec_create (void);
 void infovec_destroy (struct infovec *iv);
 
 int infovec_set_u32 (struct infovec *iv, const char *key, uint32_t val);
+int infovec_set_u16 (struct infovec *iv, const char *key, uint16_t val);
 int infovec_set_str (struct infovec *iv, const char *key, const char *str);
 int infovec_set_str_new (struct infovec *iv, const char *key, char *str);
 int infovec_set_bool (struct infovec *iv, const char *key, bool val);

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -15,6 +15,8 @@
 #include "config.h"
 #endif
 #include <flux/shell.h>
+#include <flux/taskmap.h>
+#include <flux/idset.h>
 
 #include <pmix_server.h>
 #include <pmix.h>
@@ -36,6 +38,7 @@ struct px {
     int shell_rank;
     int local_nprocs;
     int total_nprocs;
+    const struct taskmap *taskmap;
     const char *job_tmpdir;
     struct interthread *it;
     struct fence *fence;
@@ -129,6 +132,54 @@ static int set_proc_map (struct infovec *iv,
     return 0;
 }
 
+static int get_local_rank (const struct taskmap *taskmap,
+                           int nodeid,
+                           int rank)
+{
+    const struct idset *ranks;
+    unsigned int i;
+    int local_rank = 0;
+
+    if (!(ranks = taskmap_taskids (taskmap, nodeid)))
+        return -1;
+    i = idset_first (ranks);
+    while (i != IDSET_INVALID_ID) {
+        if (i == rank)
+            return local_rank;
+        local_rank++;
+        i = idset_next (ranks, i);
+    }
+    return -1;
+}
+
+static int set_proc_infos (struct infovec *iv,
+                           const char *key,
+                           struct px *px)
+{
+    struct infovec *ri;
+
+    for (int i = 0; i < px->total_nprocs; i++) {
+        int nodeid;
+        int local_rank;
+
+        if ((nodeid = taskmap_nodeid (px->taskmap, i)) < 0
+            || (local_rank = get_local_rank (px->taskmap, nodeid, i)) < 0)
+            return -1;
+
+        if (!(ri = infovec_create ())
+            || infovec_set_rank (ri, PMIX_RANK, i) < 0
+            || infovec_set_u32 (ri, PMIX_NODEID, nodeid) < 0
+            || infovec_set_u16 (ri, PMIX_LOCAL_RANK, local_rank) < 0
+            || infovec_set_u16 (ri, PMIX_NODE_RANK, local_rank) < 0
+            || infovec_set_infovec_new (iv, key, ri) < 0) {
+            shell_warn ("error setting %s for rank %d", key, i);
+            infovec_destroy (ri);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static int px_init (flux_plugin_t *p,
                     const char *topic,
                     flux_plugin_arg_t *arg,
@@ -171,7 +222,8 @@ static int px_init (flux_plugin_t *p,
     shell_debug ("total_nprocs = %d", px->total_nprocs);
     if (!(px->job_tmpdir = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR")))
         return -1;
-
+    if (!(px->taskmap = flux_shell_get_taskmap (shell)))
+        return -1;
 
     if (px->shell_rank == 0) {
         const char *s = PMIx_Get_version ();
@@ -220,7 +272,8 @@ static int px_init (flux_plugin_t *p,
         || infovec_set_u32 (iv, PMIX_LOCAL_SIZE, px->local_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_UNIV_SIZE, px->total_nprocs) < 0
         || infovec_set_u32 (iv, PMIX_JOB_SIZE, px->total_nprocs) < 0
-        || infovec_set_u32 (iv, PMIX_APPNUM, 0) < 0)
+        || infovec_set_u32 (iv, PMIX_APPNUM, 0) < 0
+        || set_proc_infos (iv, PMIX_PROC_INFO_ARRAY, px) < 0)
         goto error;
 
     if ((rc = PMIx_server_register_nspace (px->nspace,

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -2,8 +2,8 @@ FROM fluxrm/flux-core:bionic
 
 ARG USER=fluxuser
 ARG UID=1000
-ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OMPI_BRANCH=v5.0.0rc9
+ARG OPENPMIX_BRANCH=v4.2.2rc2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \
@@ -48,7 +48,7 @@ RUN cd /tmp \
  && git branch \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
-      --disable-man-pages --enable-debug --enable-mem-debug \
+      --disable-man-pages --disable-sphinx --enable-debug --enable-mem-debug \
       --with-pmix=external --with-libevent \
  && make -j $(nproc) \
  && sudo make install \

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -2,8 +2,8 @@ FROM fluxrm/flux-core:centos7
 
 ARG USER=fluxuser
 ARG UID=1000
-ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OMPI_BRANCH=v5.0.0rc9
+ARG OPENPMIX_BRANCH=v4.2.2rc2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \
@@ -47,7 +47,7 @@ RUN cd /tmp \
  && git branch \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
-      --disable-man-pages --enable-debug --enable-mem-debug \
+      --disable-man-pages --disable-sphinx --enable-debug --enable-mem-debug \
       --with-pmix=external --with-libevent \
  && make -j $(nproc) \
  && sudo make install \

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -2,8 +2,8 @@ FROM fluxrm/flux-core:centos8
 
 ARG USER=fluxuser
 ARG UID=1000
-ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OMPI_BRANCH=v5.0.0rc9
+ARG OPENPMIX_BRANCH=v4.2.2rc2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \
@@ -53,7 +53,7 @@ RUN cd /tmp \
  && git branch \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
-      --disable-man-pages --enable-debug --enable-mem-debug \
+      --disable-man-pages --disable-sphinx --enable-debug --enable-mem-debug \
       --with-pmix=external --with-libevent \
  && make -j $(nproc) \
  && sudo make install \

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -2,8 +2,8 @@ FROM fluxrm/flux-core:fedora34
 
 ARG USER=fluxuser
 ARG UID=1000
-ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OMPI_BRANCH=v5.0.0rc9
+ARG OPENPMIX_BRANCH=v4.2.2rc2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \
@@ -45,7 +45,7 @@ RUN cd /tmp \
  && git branch \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
-      --disable-man-pages --enable-debug --enable-mem-debug \
+      --disable-man-pages --disable-sphinx --enable-debug --enable-mem-debug \
       --with-pmix=external --with-libevent \
  && make -j $(nproc) \
  && sudo make install \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -2,8 +2,8 @@ FROM fluxrm/flux-core:focal
 
 ARG USER=fluxuser
 ARG UID=1000
-ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OMPI_BRANCH=v5.0.0rc9
+ARG OPENPMIX_BRANCH=v4.2.2rc2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \
@@ -49,7 +49,7 @@ RUN cd /tmp \
  && git branch \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
-      --disable-man-pages --enable-debug --enable-mem-debug \
+      --disable-man-pages --disable-sphinx --enable-debug --enable-mem-debug \
       --with-pmix=external --with-libevent \
  && make -j $(nproc) \
  && sudo make install \

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -21,9 +21,9 @@ test_expect_success '1n2p barrier works' '
 		${BARRIER}
 '
 
-test_expect_success '1n2p barrier tolerates pmix.timeout=2' '
+test_expect_success '1n2p barrier tolerates pmix.timeout=20' '
 	run_timeout 30 flux mini run -N1 -n2 \
-		${BARRIER} --timeout=2
+		${BARRIER} --timeout=20
 '
 
 test_expect_success '1n2p barrier tolerates pmix.collect=false' '
@@ -55,10 +55,10 @@ test_expect_success '2n2p barrier works' '
 		${BARRIER}
 '
 
-test_expect_success '2n2p barrier tolerates optional pmix.timeout=2' '
+test_expect_success '2n2p barrier tolerates optional pmix.timeout=20' '
 	run_timeout 30 flux mini run -N2 -n2 \
 		-overbose=2 \
-		${BARRIER} --timeout=2
+		${BARRIER} --timeout=20
 '
 
 test_expect_success '2n2p barrier tolerates optional pmix.collect=false' '

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -23,7 +23,7 @@ test_expect_success '1n2p barrier works' '
 
 test_expect_success '1n2p barrier tolerates pmix.timeout=2' '
 	run_timeout 30 flux mini run -N1 -n2 \
-		${BARRIER} --timeout=2s
+		${BARRIER} --timeout=2
 '
 
 test_expect_success '1n2p barrier tolerates pmix.collect=false' '
@@ -58,7 +58,7 @@ test_expect_success '2n2p barrier works' '
 test_expect_success '2n2p barrier tolerates optional pmix.timeout=2' '
 	run_timeout 30 flux mini run -N2 -n2 \
 		-overbose=2 \
-		${BARRIER} --timeout=2s
+		${BARRIER} --timeout=2
 '
 
 test_expect_success '2n2p barrier tolerates optional pmix.collect=false' '


### PR DESCRIPTION
Problem:  flux-pmix does not work with the newer openpmix and ompi 5 branches

Nail down the versions that we test with in CI now that ompi v5 has tagged releases.  Choose a version of openpmix that matches the one in the opmi release's submodule reference.

The new version required different namespace setup, so do what appears to be the minimum to get things working.

Also: use the new taskmap interface to create the "maps" pmix wants instead of constructing by hand.