### PR TITLE
plugin: populate PMIX_PROC_INFO_ARRAY

### DIFF
--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -150,6 +150,7 @@ void infovec_destroy (struct infovec *iv)
                     break;
             }
         }
+        free (iv->info);
         free (iv);
         errno = saved_errno;
     }

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -128,6 +128,31 @@ int infovec_set_rank (struct infovec *iv,
     return 0;
 }
 
+int infovec_set_infovec_new (struct infovec *iv,
+                             const char *key,
+                             struct infovec *val)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strlcpy (info->key, key, sizeof (info->key));
+    info->value.type = PMIX_DATA_ARRAY;
+    if (!(info->value.data.darray = calloc (1, sizeof (pmix_data_array_t))))
+        return -1;
+    /* steal val->info and free val */
+    info->value.data.darray->type = PMIX_INFO;
+    info->value.data.darray->size = val->count;
+    info->value.data.darray->array = val->info;
+    free (val);
+
+    return 0;
+}
+
 int infovec_count (struct infovec *iv)
 {
     return iv->count;
@@ -138,19 +163,33 @@ pmix_info_t *infovec_info (struct infovec *iv)
     return iv->info;
 }
 
-void infovec_destroy (struct infovec *iv)
+static void destroy_info_array (pmix_info_t *info, int count)
 {
-    if (iv) {
-        int saved_errno = errno;
-        for (int i = 0; i < iv->count; i++) {
-            pmix_value_t *value = &iv->info[i].value;
+    if (info) {
+        for (int i = 0; i < count; i++) {
+            pmix_value_t *value = &info[i].value;
             switch (value->type) {
                 case PMIX_STRING:
                     free (value->data.string);
                     break;
+                case PMIX_DATA_ARRAY:
+                    if (value->data.darray) { // recurse
+                        destroy_info_array (value->data.darray->array,
+                                            value->data.darray->size);
+                        free (value->data.darray);
+                    }
+                    break;
             }
         }
-        free (iv->info);
+        free (info);
+    }
+}
+
+void infovec_destroy (struct infovec *iv)
+{
+    if (iv) {
+        int saved_errno = errno;
+        destroy_info_array (iv->info, iv->count);
         free (iv);
         errno = saved_errno;
     }

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -94,6 +94,22 @@ int infovec_set_u32 (struct infovec *iv, const char *key, uint32_t value)
     return 0;
 }
 
+int infovec_set_u16 (struct infovec *iv, const char *key, uint16_t value)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strlcpy (info->key, key, sizeof (info->key));
+    info->value.type = PMIX_UINT16;
+    info->value.data.uint16 = value;
+    return 0;
+}
+
 int infovec_set_bool (struct infovec *iv, const char *key, bool value)
 {
     pmix_info_t *info;

--- a/src/shell/plugins/infovec.h
+++ b/src/shell/plugins/infovec.h
@@ -21,6 +21,9 @@ int infovec_set_str (struct infovec *iv, const char *key, const char *str);
 int infovec_set_str_new (struct infovec *iv, const char *key, char *str);
 int infovec_set_bool (struct infovec *iv, const char *key, bool val);
 int infovec_set_rank (struct infovec *iv, const char *key, pmix_rank_t val);
+int infovec_set_infovec_new (struct infovec *iv,
+                             const char *key,
+                             struct infovec *val);
 
 int infovec_count (struct infovec *iv);
 pmix_info_t *infovec_info (struct infovec *iv);

--- a/src/shell/plugins/infovec.h
+++ b/src/shell/plugins/infovec.h
@@ -17,6 +17,7 @@ struct infovec *infovec_create (void);
 void infovec_destroy (struct infovec *iv);
 
 int infovec_set_u32 (struct infovec *iv, const char *key, uint32_t val);
+int infovec_set_u16 (struct infovec *iv, const char *key, uint16_t val);
 int infovec_set_str (struct infovec *iv, const char *key, const char *str);
 int infovec_set_str_new (struct infovec *iv, const char *key, char *str);
 int infovec_set_bool (struct infovec *iv, const char *key, bool val);


### PR DESCRIPTION
Problem: the latest ompi v5 work requires a newer openpmix, but flux-pmix fails with the newer openpmix, apparently because it doesn't populate the PMIX_PROC_INFO_ARRAY.

Take care of this, then bump the openpmix version used in CI.