### PR TITLE
ci: update el builders and force ompi v5.0.0rc2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,14 @@ jobs:
           ompi_branch: "v5.0.x"
           coverage: false
           env: {}
-        - name: "centos7 - ompi v5.0.x, chain_lint"
-          image: "centos7"
+        - name: "el7 - ompi v5.0.x, chain_lint"
+          image: "el7"
           ompi_branch: "v5.0.x"
           coverage: false
           env:
             chain_lint: t
-        - name: "centos8 - ompi v5.0.x, distcheck"
-          image: "centos8"
+        - name: "el8 - ompi v5.0.x, distcheck"
+          image: "el8"
           ompi_branch: "v5.0.x"
           coverage: false
           env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,32 +22,32 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: "focal - ompi v5.0.x"
+        - name: "focal - ompi v5.0.0rc2"
           image: "focal"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc2"
           coverage: false
           env: {}
-        - name: "el7 - ompi v5.0.x, chain_lint"
+        - name: "el7 - ompi v5.0.0rc2, chain_lint"
           image: "el7"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc2"
           coverage: false
           env:
             chain_lint: t
-        - name: "el8 - ompi v5.0.x, distcheck"
+        - name: "el8 - ompi v5.0.0rc2, distcheck"
           image: "el8"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc2"
           coverage: false
           env:
             DISTCHECK: t
         - name: "coverage"
           image: "focal"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc2"
           coverage: true
           env:
             COVERAGE: t
-        - name: "fedora34 - ompi v5.0.x"
+        - name: "fedora34 - ompi v5.0.0rc2"
           image: "fedora34"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc2"
           coverage: false
           env: {}
         - name: "focal - ompi v4.1.x"

--- a/src/test/docker/el7/Dockerfile
+++ b/src/test/docker/el7/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:centos7
+FROM fluxrm/flux-core:el7
 
 ARG USER=fluxuser
 ARG UID=1000

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:centos8
+FROM fluxrm/flux-core:el8
 
 ARG USER=fluxuser
 ARG UID=1000

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -41,6 +41,7 @@ RUN cd /tmp \
  && ./configure --prefix=/usr \
       --enable-debug \
  && make -j $(nproc) \
+ && sudo rm -rf /usr/lib64/pmix \
  && sudo make install \
  && cd .. \
  && rm -rf openpmix

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -5,6 +5,7 @@ test_description='Exercise empty fence (barrier).'
 . `dirname $0`/sharness.sh
 
 BARRIER=${FLUX_BUILD_DIR}/t/src/barrier
+VERSION=${FLUX_BUILD_DIR}/t/src/version
 export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
 
 test_under_flux 2

--- a/t/t0004-bizcard.t
+++ b/t/t0004-bizcard.t
@@ -5,6 +5,7 @@ test_description='Exercise the business card exchange use case.'
 . `dirname $0`/sharness.sh
 
 BIZCARD=${FLUX_BUILD_DIR}/t/src/bizcard
+VERSION=${FLUX_BUILD_DIR}/t/src/version
 
 export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
 


### PR DESCRIPTION
Problem: builds are failing because the ompi v5.0.x branch now requires openpmix v4.2.2.
    
For the moment, reconfigure CI to lock in the ompi v5.0.0rc2 tag, which works with openpmix v4.1.1.

Thanks to @grondo for providing the patch to modernize the el builders also.
