### PR TITLE
plugin: use flux taskmap class to generate lpeers, procmap

### DIFF
--- a/config/ax_flux_core.m4
+++ b/config/ax_flux_core.m4
@@ -28,6 +28,8 @@
 #   - FLUX_OPTPARSE_CFLAGS libflux-optparse CFLAGS
 #   - FLUX_HOSTLIST_LIBS   libflux-hostlist LIBS
 #   - FLUX_HOSTLIST_CFLAGS libflux-hostlist CFLAGS
+#   - FLUX_TASKMAP_LIBS    libflux-taskmap LIBS
+#   - FLUX_TASKMAP_CFLAGS  libflux-taskmap CFLAGS
 #
 # LICENSE
 #
@@ -49,7 +51,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH}
   export PKG_CONFIG_PATH
 
-  PKG_CHECK_MODULES([FLUX_CORE], [flux-core > 0.29.0],
+  PKG_CHECK_MODULES([FLUX_CORE], [flux-core >= 0.46.0],
     [
       FLUX_PREFIX=`pkg-config --variable=prefix flux-core`
       LIBFLUX_VERSION=`pkg-config --modversion flux-core`
@@ -79,6 +81,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CHECK_MODULES([FLUX_SCHEDUTIL], [flux-schedutil], [], [])
   PKG_CHECK_MODULES([FLUX_OPTPARSE], [flux-optparse], [], [])
   PKG_CHECK_MODULES([FLUX_HOSTLIST], [flux-hostlist], [], [])
+  PKG_CHECK_MODULES([FLUX_TASKMAP], [flux-taskmap], [], [])
 
   PKG_CONFIG_PATH=$saved_PKG_CONFIG_PATH
   export PKG_CONFIG_PATH

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -38,6 +38,7 @@ pmix_la_CPPFLAGS = \
 	$(FLUX_CORE_CFLAGS) \
 	$(FLUX_IDSET_CFLAGS) \
 	$(FLUX_HOSTLIST_CFLAGS) \
+	$(FLUX_TASKMAP_CFLAGS) \
 	$(PMIX_CFLAGS) \
 	$(JANSSON_CFLAGS)
 pmix_la_LIBADD = \
@@ -45,6 +46,7 @@ pmix_la_LIBADD = \
 	$(PMIX_LIBS) \
 	$(FLUX_IDSET_LIBS) \
 	$(FLUX_HOSTLIST_LIBS) \
+	$(FLUX_TASKMAP_LIBS) \
 	$(JANSSON_LIBS) \
 	$(top_builddir)/src/common/libccan/libccan.la \
 	$(top_builddir)/src/common/libutil/libutil.la

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -112,13 +112,13 @@ static int set_node_map (struct infovec *iv,
 
 static int set_proc_map (struct infovec *iv,
                          const char *key,
-                         flux_shell_t *shell)
+                         const struct taskmap *taskmap)
 {
     char *raw;
     char *cooked;
     int rc;
 
-    if (!(raw = maps_proc_create (shell)))
+    if (!(raw = taskmap_encode (taskmap, TASKMAP_ENCODE_RAW_DERANGED)))
         return -1;
     shell_debug ("proc_map = %s", raw);
     if ((rc = PMIx_generate_ppn (raw, &cooked) != PMIX_SUCCESS)) {
@@ -221,7 +221,7 @@ static int px_init (flux_plugin_t *p,
         || infovec_set_str (iv, PMIX_JOBID, px->nspace) < 0
         || set_lpeers (iv, PMIX_LOCAL_PEERS, px->taskmap, px->shell_rank) < 0
         || set_node_map (iv, PMIX_NODE_MAP, shell) < 0
-        || set_proc_map (iv, PMIX_PROC_MAP, shell) < 0
+        || set_proc_map (iv, PMIX_PROC_MAP, px->taskmap) < 0
         || infovec_set_bool (iv, PMIX_TDIR_RMCLEAN, true) < 0
         || infovec_set_u32 (iv, PMIX_JOB_NUM_APPS, 1) < 0
         || infovec_set_str (iv, PMIX_TMPDIR, px->job_tmpdir) < 0

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -15,6 +15,8 @@
 #include "config.h"
 #endif
 #include <flux/shell.h>
+#include <flux/taskmap.h>
+#include <flux/idset.h>
 
 #include <pmix_server.h>
 #include <pmix.h>
@@ -36,6 +38,7 @@ struct px {
     int shell_rank;
     int local_nprocs;
     int total_nprocs;
+    const struct taskmap *taskmap;
     const char *job_tmpdir;
     struct interthread *it;
     struct fence *fence;
@@ -65,11 +68,14 @@ static void px_destroy (struct px *px)
 
 static int set_lpeers (struct infovec *iv,
                        const char *key,
-                       flux_shell_t *shell)
+                       const struct taskmap *taskmap,
+                       int shell_rank)
 {
+    const struct idset *ids;
     char *s;
 
-    if (!(s = maps_lpeers_create (shell)))
+    if (!(ids = taskmap_taskids (taskmap, shell_rank))
+        || !(s = idset_encode (ids, 0)))
         return -1;
     shell_debug ("local_peers = %s", s);
     if (infovec_set_str_new (iv, key, s) < 0) { // steals s
@@ -172,6 +178,8 @@ static int px_init (flux_plugin_t *p,
     if (!(px->job_tmpdir = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR")))
         return -1;
 
+    if (!(px->taskmap = flux_shell_get_taskmap (shell)))
+        return -1;
 
     if (px->shell_rank == 0) {
         const char *s = PMIx_Get_version ();
@@ -211,7 +219,7 @@ static int px_init (flux_plugin_t *p,
 
     if (!(iv = infovec_create ())
         || infovec_set_str (iv, PMIX_JOBID, px->nspace) < 0
-        || set_lpeers (iv, PMIX_LOCAL_PEERS, shell) < 0
+        || set_lpeers (iv, PMIX_LOCAL_PEERS, px->taskmap, px->shell_rank) < 0
         || set_node_map (iv, PMIX_NODE_MAP, shell) < 0
         || set_proc_map (iv, PMIX_PROC_MAP, shell) < 0
         || infovec_set_bool (iv, PMIX_TDIR_RMCLEAN, true) < 0

--- a/src/shell/plugins/maps.c
+++ b/src/shell/plugins/maps.c
@@ -34,20 +34,6 @@ static char *derange_idset (const char *in)
     return out;
 }
 
-char *maps_lpeers_create (flux_shell_t *shell)
-{
-    int shell_rank;
-    const char *taskids;
-
-    if (flux_shell_info_unpack (shell, "{s:i}", "rank", &shell_rank) < 0
-        || flux_shell_rank_info_unpack (shell,
-                                        shell_rank,
-                                        "{s:s}",
-                                        "taskids", &taskids) < 0)
-        return NULL;
-    return derange_idset (taskids);
-}
-
 /* Iterate over each shell, creating an idset of ranks.
  * Create a semicolon delimited list of idsets, where each entry
  * represents a set of ranks on a shell.

--- a/src/shell/plugins/maps.c
+++ b/src/shell/plugins/maps.c
@@ -22,50 +22,6 @@
 
 #include "maps.h"
 
-static char *derange_idset (const char *in)
-{
-    struct idset *ids;
-    char *out;
-
-    if (!(ids = idset_decode (in)))
-        return NULL;
-    out = idset_encode (ids, 0);
-    idset_destroy (ids);
-    return out;
-}
-
-/* Iterate over each shell, creating an idset of ranks.
- * Create a semicolon delimited list of idsets, where each entry
- * represents a set of ranks on a shell.
- * E.g. "0,1;2,3" means ranks 0,1 on shell 0; ranks 2,3 on shell 1.
- */
-char *maps_proc_create (flux_shell_t *shell)
-{
-    int shell_size;
-    char *argz = NULL;
-    size_t argz_len = 0;
-    const char *taskids;
-    char *s = NULL;
-
-    if (flux_shell_info_unpack (shell, "{s:i}", "size", &shell_size) < 0)
-        return NULL;
-    for (int shell_rank = 0; shell_rank < shell_size; shell_rank++) {
-        if (flux_shell_rank_info_unpack (shell,
-                                         shell_rank,
-                                         "{s:s}",
-                                         "taskids", &taskids) < 0
-            || !(s = derange_idset (taskids))
-            || argz_add (&argz, &argz_len, s) != 0) {
-            free (s);
-            free (argz);
-            return NULL;
-        }
-        free (s);
-    }
-    argz_stringify (argz, argz_len, ';');
-    return argz;
-}
-
 static bool contains_duplicates (struct hostlist *hl)
 {
     struct hostlist *hl2;

--- a/src/shell/plugins/maps.h
+++ b/src/shell/plugins/maps.h
@@ -13,7 +13,6 @@
 
 #include <flux/shell.h>
 
-char *maps_lpeers_create (flux_shell_t *shell);
 char *maps_proc_create (flux_shell_t *shell);
 char *maps_node_create (flux_shell_t *shell);
 

--- a/src/shell/plugins/maps.h
+++ b/src/shell/plugins/maps.h
@@ -13,7 +13,6 @@
 
 #include <flux/shell.h>
 
-char *maps_proc_create (flux_shell_t *shell);
 char *maps_node_create (flux_shell_t *shell);
 
 #endif // _PX_MAPS_H


### PR DESCRIPTION
Problem: code for generating "maps" is no longer needed now that flux-core has taskmaps.

Use the new interface and throw away some code.