### PR TITLE
switch to openpmix 4.2.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,9 @@ jobs:
         --build-arg OMPI_BRANCH=${{ matrix.ompi_branch }}
         --
 
+    - if: failure()
+      uses: mxschmitt/action-tmate@v3
+
     - name: annotate errors
       if: failure() || cancelled()
       run: src/test/checks-annotate.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,32 +22,32 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: "focal - ompi v5.0.0rc2"
+        - name: "focal - ompi v5.0.x"
           image: "focal"
-          ompi_branch: "v5.0.0rc2"
+          ompi_branch: "v5.0.x"
           coverage: false
           env: {}
-        - name: "el7 - ompi v5.0.0rc2, chain_lint"
+        - name: "el7 - ompi v5.0.x, chain_lint"
           image: "el7"
-          ompi_branch: "v5.0.0rc2"
+          ompi_branch: "v5.0.x"
           coverage: false
           env:
             chain_lint: t
-        - name: "el8 - ompi v5.0.0rc2, distcheck"
+        - name: "el8 - ompi v5.0.x, distcheck"
           image: "el8"
-          ompi_branch: "v5.0.0rc2"
+          ompi_branch: "v5.0.x"
           coverage: false
           env:
             DISTCHECK: t
         - name: "coverage"
           image: "focal"
-          ompi_branch: "v5.0.0rc2"
+          ompi_branch: "v5.0.x"
           coverage: true
           env:
             COVERAGE: t
-        - name: "fedora34 - ompi v5.0.0rc2"
+        - name: "fedora34 - ompi v5.0.x"
           image: "fedora34"
-          ompi_branch: "v5.0.0rc2"
+          ompi_branch: "v5.0.x"
           coverage: false
           env: {}
         - name: "focal - ompi v4.1.x"

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -49,7 +49,7 @@ RUN cd /tmp \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
       --disable-man-pages --enable-debug --enable-mem-debug \
-      --with-pmix=external --with-libevent \
+      --with-pmix=external --with-libevent --disable-sphinx \
  && make -j $(nproc) \
  && sudo make install \
  && cd .. \

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -3,7 +3,7 @@ FROM fluxrm/flux-core:bionic
 ARG USER=fluxuser
 ARG UID=1000
 ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OPENPMIX_BRANCH=v4.2.2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \

--- a/src/test/docker/el7/Dockerfile
+++ b/src/test/docker/el7/Dockerfile
@@ -48,7 +48,7 @@ RUN cd /tmp \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
       --disable-man-pages --enable-debug --enable-mem-debug \
-      --with-pmix=external --with-libevent \
+      --with-pmix=external --with-libevent --disable-sphinx \
  && make -j $(nproc) \
  && sudo make install \
  && cd .. \

--- a/src/test/docker/el7/Dockerfile
+++ b/src/test/docker/el7/Dockerfile
@@ -3,7 +3,7 @@ FROM fluxrm/flux-core:el7
 ARG USER=fluxuser
 ARG UID=1000
 ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OPENPMIX_BRANCH=v4.2.2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -55,7 +55,7 @@ RUN cd /tmp \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
       --disable-man-pages --enable-debug --enable-mem-debug \
-      --with-pmix=external --with-libevent \
+      --with-pmix=external --with-libevent --disable-sphinx \
  && make -j $(nproc) \
  && sudo make install \
  && cd .. \

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -3,7 +3,7 @@ FROM fluxrm/flux-core:el8
 ARG USER=fluxuser
 ARG UID=1000
 ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OPENPMIX_BRANCH=v4.2.2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -46,7 +46,7 @@ RUN cd /tmp \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
       --disable-man-pages --enable-debug --enable-mem-debug \
-      --with-pmix=external --with-libevent \
+      --with-pmix=external --with-libevent --disable-sphinx \
  && make -j $(nproc) \
  && sudo make install \
  && cd .. \

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -3,7 +3,7 @@ FROM fluxrm/flux-core:fedora34
 ARG USER=fluxuser
 ARG UID=1000
 ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OPENPMIX_BRANCH=v4.2.2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -50,7 +50,7 @@ RUN cd /tmp \
  && ./autogen.pl \
  && ./configure --prefix=/usr \
       --disable-man-pages --enable-debug --enable-mem-debug \
-      --with-pmix=external --with-libevent \
+      --with-pmix=external --with-libevent --disable-sphinx \
  && make -j $(nproc) \
  && sudo make install \
  && cd .. \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -3,7 +3,7 @@ FROM fluxrm/flux-core:focal
 ARG USER=fluxuser
 ARG UID=1000
 ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.1.1rc2
+ARG OPENPMIX_BRANCH=v4.2.2
 
 RUN \
  if test "$USER" != "fluxuser"; then  \

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -24,7 +24,7 @@ test_expect_success '1n2p barrier works' '
 
 test_expect_success '1n2p barrier tolerates pmix.timeout=2' '
 	run_timeout 30 flux mini run -N1 -n2 \
-		${BARRIER} --timeout=2s
+		${BARRIER} --timeout=2
 '
 
 test_expect_success '1n2p barrier tolerates pmix.collect=false' '
@@ -59,7 +59,7 @@ test_expect_success '2n2p barrier works' '
 test_expect_success '2n2p barrier tolerates optional pmix.timeout=2' '
 	run_timeout 30 flux mini run -N2 -n2 \
 		-overbose=2 \
-		${BARRIER} --timeout=2s
+		${BARRIER} --timeout=2
 '
 
 test_expect_success '2n2p barrier tolerates optional pmix.collect=false' '


### PR DESCRIPTION
This pushes the version of openpmix that we build against forward to 4.2.2.
In addition, it reverts the lock-in of ompi-v5.0.0rc2 in CI.