### PR TITLE
fix spurious test failure and add improved debug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,9 +89,6 @@ jobs:
         --build-arg OMPI_BRANCH=${{ matrix.ompi_branch }}
         --
 
-    - if: failure()
-      uses: mxschmitt/action-tmate@v3
-
     - name: annotate errors
       if: failure() || cancelled()
       run: src/test/checks-annotate.sh

--- a/src/shell/plugins/codec.c
+++ b/src/shell/plugins/codec.c
@@ -271,6 +271,10 @@ int codec_value_decode (json_t *o, pmix_value_t *value)
     int type;
     json_t *data;
 
+    /* Zero-fill any unused memory in the pmix_value_t union.
+     */
+    memset (value, 0, sizeof (*value));
+
     if (json_unpack (o,
                      "{s:i s:o}",
                      "type", &type,

--- a/src/shell/plugins/fence.c
+++ b/src/shell/plugins/fence.c
@@ -159,6 +159,11 @@ static void fence_shell_cb (const flux_msg_t *msg, void *arg)
         if ((rc = parse_fence_attr (fxcall, &fxcall->info[i])) != PMIX_SUCCESS)
             goto error;
     }
+    if (fx->trace_flag) {
+        shell_trace ("starting pmix exchange %d: size %zi",
+                     fxcall->exchange_seq,
+                     fxcall->collect ? codec_data_length (xdata) : 0);
+    }
     if (exchange_enter_base64_string (fx->exchange,
                                       fxcall->collect ? xdata : NULL,
                                       exchange_exit_cb,
@@ -167,10 +172,6 @@ static void fence_shell_cb (const flux_msg_t *msg, void *arg)
         rc = PMIX_ERROR;
         goto error;
     }
-    if (fx->trace_flag)
-        shell_trace ("starting pmix exchange %d: size %zi",
-                     fxcall->exchange_seq,
-                     fxcall->collect ? codec_data_length (xdata) : 0);
     return;
 error:
     fxcall->cbfunc (rc, NULL, 0, fxcall->cbdata, NULL, NULL);

--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -31,6 +31,8 @@ struct infovec {
 
 static pmix_info_t *alloc_slot (struct infovec *iv)
 {
+    pmix_info_t *info;
+
     if (iv->count == iv->length) {
         int new_length = iv->length + INFOVEC_CHUNK;
         size_t new_size = sizeof (iv->info[0]) * new_length;
@@ -41,7 +43,9 @@ static pmix_info_t *alloc_slot (struct infovec *iv)
         iv->info = new_info;
         iv->length = new_length;
     }
-    return &iv->info[iv->count++];
+    info = &iv->info[iv->count++];
+    memset (info, 0, sizeof (*info));
+    return info;
 }
 
 int infovec_set_str_new (struct infovec *iv, const char *key, char *val)

--- a/t/src/barrier.c
+++ b/t/src/barrier.c
@@ -212,6 +212,9 @@ int main (int argc, char **argv)
     monotime (&t);
     pmix_info_t info[8];
     pmix_proc_t *procs = NULL;
+
+    memset (info, 0, sizeof (info));
+
     size_t ninfo = parse_info_opts (p, info, sizeof (info) / sizeof (info[0]));
     size_t nprocs = parse_procs_opt (p, &self, &procs);
 

--- a/t/src/barrier.c
+++ b/t/src/barrier.c
@@ -58,6 +58,7 @@ void set_info_bool (pmix_info_t *info,
     info->flags = flags;
     info->value.type = PMIX_BOOL;
     info->value.data.flag = value;
+    log_msg ("Setting %s=%s flags=%d", name, value ? "true" : "false", flags);
 }
 
 void set_info_int (pmix_info_t *info,
@@ -69,6 +70,7 @@ void set_info_int (pmix_info_t *info,
     info->flags = flags;
     info->value.type = PMIX_INT;
     info->value.data.flag = optarg;
+    log_msg ("Setting %s=%d flags=%d", name, optarg, flags);
 }
 
 size_t parse_info_opts (optparse_t *p, pmix_info_t *infos, size_t ninfo)

--- a/t/t0003-barrier.t
+++ b/t/t0003-barrier.t
@@ -23,7 +23,7 @@ test_expect_success '1n2p barrier works' '
 '
 
 test_expect_success '1n2p barrier tolerates pmix.timeout=2' '
-	run_timeout 30 flux mini run -N1 -n2 \
+	run_timeout 30 flux mini run -N1 -n2 -overbose=2 \
 		${BARRIER} --timeout=2
 '
 


### PR DESCRIPTION
Zeroing `pmix_value_t` storage before use seems to both shut up valgrind and resolve issue #69.  As pointed out by @grondo, the supposed fix may just be eliminating spurious valgrind warnings.  Why the issue goes away is unknown, but maybe there's some other effect going on in the pmix server code that I'm missing.  I guess we can reopen if it recurs.

