### PR TITLE
make testing of ompi < v5 more robust

### DIFF
--- a/t/src/bizcard.c
+++ b/t/src/bizcard.c
@@ -131,6 +131,7 @@ int main (int argc, char **argv)
 
     /* Fence
      */
+    memset (&info, 0, sizeof (info));
     strlcpy (info.key, PMIX_COLLECT_DATA, sizeof (info.key));
     info.value.type = PMIX_BOOL;
     info.value.data.flag = true;

--- a/t/src/notify.c
+++ b/t/src/notify.c
@@ -86,6 +86,7 @@ int main (int argc, char **argv)
     /* Add any info options
      */
     if (event_message) {
+        memset (&info[ninfo], 0, sizeof (info));
         strlcpy (info[ninfo].key,
                  PMIX_EVENT_TEXT_MESSAGE,
                  sizeof (info[ninfo].key));

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -12,7 +12,7 @@ export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
 test_under_flux 2
 
 test_expect_success 'capture the job environment' '
-	run_timeout 30 flux mini run \
+	run_timeout 30 flux mini run -opmi=off \
 		printenv >printenv.out
 '
 
@@ -26,12 +26,12 @@ test_expect_success 'sanity check pmix environment' '
 '
 
 test_expect_success '1n2p ompi hello' '
-	run_timeout 30 flux mini run -N1 -n2 \
+	run_timeout 30 flux mini run -opmi=off -N1 -n2 \
 		${MPI_HELLO}
 '
 
 test_expect_success '2n2p ompi hello' '
-	run_timeout 30 flux mini run -N2 -n2 \
+	run_timeout 30 flux mini run -opmi=off -N2 -n2 \
 		${MPI_HELLO}
 '
 
@@ -43,24 +43,24 @@ test_expect_success '2n2p ompi hello' '
 
 # see issue #27
 test_expect_success '2n3p ompi hello doesnt hang' '
-	run_timeout 60 flux mini run -N2 -n3 \
+	run_timeout 60 flux mini run -opmi=off -N2 -n3 \
 		-overbose=2 \
 		${MPI_HELLO}
 '
 
 # see issue #26
 test_expect_success '2n4p ompi hello reports no system call errors' '
-        run_timeout 30 flux mini run -N2 -n4 \
+        run_timeout 30 flux mini run -opmi=off -N2 -n4 \
                 ${MPI_HELLO} 2>2n4p_hello.err &&
         test_must_fail grep "System call:" 2n4p_hello.err
 '
 
 test_expect_success '1n2p ompi pingpong works' '
-        run_timeout 30 flux mini run -N1 -n2 \
+        run_timeout 30 flux mini run -opmi=off -N1 -n2 \
                 ${MPI_PINGPONG}
 '
 test_expect_success '2n2p ompi pingpong works' '
-        run_timeout 30 flux mini run -N2 -n2 \
+        run_timeout 30 flux mini run -opmi=off -N2 -n2 \
                 ${MPI_PINGPONG}
 '
 

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -27,12 +27,14 @@ test_expect_success 'sanity check pmix environment' '
 
 test_expect_success '1n2p ompi hello' '
 	run_timeout 30 flux mini run -opmi=off -N1 -n2 \
-		${MPI_HELLO}
+		${MPI_HELLO} >hello_1n2p.out &&
+	grep "There are 2 tasks" hello_1n2p.out
 '
 
 test_expect_success '2n2p ompi hello' '
 	run_timeout 30 flux mini run -opmi=off -N2 -n2 \
-		${MPI_HELLO}
+		${MPI_HELLO} >hello_2n2p.out &&
+	grep "There are 2 tasks" hello_2n2p.out
 '
 
 # Useful debugging runes:
@@ -45,7 +47,8 @@ test_expect_success '2n2p ompi hello' '
 test_expect_success '2n3p ompi hello doesnt hang' '
 	run_timeout 60 flux mini run -opmi=off -N2 -n3 \
 		-overbose=2 \
-		${MPI_HELLO}
+		${MPI_HELLO} >hello_2n3p.out &&
+	grep "There are 3 tasks" hello_2n3p.out
 '
 
 # see issue #26

--- a/t/t2001-osu-benchmarks.t
+++ b/t/t2001-osu-benchmarks.t
@@ -72,7 +72,7 @@ run_osutest() {
 	local nnodes=$2
 	local ntasks=$3
 	local cmd=$4
-	run_timeout $timeout flux mini run -N$nnodes -n$ntasks \
+	run_timeout $timeout flux mini run -opmi=off -N$nnodes -n$ntasks \
 		${OSU_MPI}/${cmd}
 }
 

--- a/t/t2002-mpibench.t
+++ b/t/t2002-mpibench.t
@@ -49,7 +49,7 @@ run_mpibench() {
 	local nnodes=$2
 	local ntasks=$3
 	local op=$4
-	run_timeout $timeout flux mini run -N$nnodes -n$ntasks \
+	run_timeout $timeout flux mini run -opmi=off -N$nnodes -n$ntasks \
 		${MPIBENCH} ${op}
 }
 


### PR DESCRIPTION
Problem: since PMI-1 is always active, it's not entirely clear that the testsuite covers using pmix to bootstrap ompi version < v5.

Disable PMI-1 service with `-o mpi=off` in the MPI tests.
Add some checks in the mpi tests to ensure multiple singletons are not started.

Toss in another small change to zero more `pmix_value_t` objects in test programs.