### PR TITLE
build: make the ompi prereq optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,11 +6,11 @@ AC_INIT([flux-pmix],
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS.md])
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE([subdir-objects tar-pax foreign])
 AM_SILENT_RULES([yes])
-AM_CONFIG_HEADER([config/config.h])
+AC_CONFIG_HEADERS([config/config.h])
 AM_MAINTAINER_MODE([enable])
 
 AC_DEFINE([_GNU_SOURCE], 1,
@@ -32,7 +32,7 @@ PKG_PROG_PKG_CONFIG
 
 # Checks for programs
 ##
-AC_PROG_CC_C99
+m4_version_prereq(2.70, [AC_PROG_CC], [AC_PROG_CC_C99])
 AM_PROG_CC_C_O
 AX_COMPILER_VENDOR
 AX_COMPILER_VERSION
@@ -44,8 +44,6 @@ AS_CASE($ax_cv_c_compiler_vendor,
 AC_SUBST([WARNING_CFLAGS])
 
 LT_INIT
-
-AC_HEADER_STDC
 
 PKG_CHECK_MODULES([PMIX], [pmix >= 4.0.0])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])

--- a/configure.ac
+++ b/configure.ac
@@ -48,13 +48,16 @@ LT_INIT
 PKG_CHECK_MODULES([PMIX], [pmix >= 4.0.0])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
 
-PKG_CHECK_MODULES([OMPI], [ompi >= 3.0.0], [
+PKG_CHECK_MODULES([OMPI], [ompi >= 3.0.0], [have_ompi=yes], [have_ompi=no])
+if test "${have_ompi}" = "yes"; then
   OMPI_PREFIX=`pkg-config --variable=prefix ompi`
   if test -z "${OMPI_PREFIX}"; then
     AC_MSG_ERROR([failed to determine ompi prefix from pkg-config])
   fi
   AC_SUBST(OMPI_PREFIX)
-])
+  AC_DEFINE(HAVE_MPI, [1], [whether to build mpi tests])
+fi
+AM_CONDITIONAL([HAVE_MPI], [test "x$have_ompi" = "xyes"])
 
 X_AC_CHECK_PTHREADS
 

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,6 @@ LT_INIT
 
 AC_HEADER_STDC
 
-PKG_CHECK_MODULES([ZMQ], [libczmq >= 3.0.0 libzmq >= 4.0.4])
 PKG_CHECK_MODULES([PMIX], [pmix >= 4.0.0])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,8 @@
-SUBDIRS = src osu-micro-benchmarks .
+SUBDIRS = src .
+
+if HAVE_MPI
+SUBDIRS += osu-micro-benchmarks
+endif
 
 AM_CFLAGS = \
 	$(WARNING_CFLAGS) \
@@ -41,8 +45,10 @@ TESTS = \
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS)
 
+if HAVE_MPI
 check_PROGRAMS = \
 	mpibench/mpibench
+endif
 
 check-prep:
 	$(MAKE)

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -19,10 +19,14 @@ check_PROGRAMS = \
 	getkey \
 	abort \
 	notify \
+	mpi_version
+
+if HAVE_MPI
+check_PROGRAMS += \
 	mpi_hello \
-	mpi_version \
 	mpi_abort \
 	mpi_pingpong
+endif
 
 check_LTLIBRARIES = libtestutil.la
 

--- a/t/src/mpi_version.c
+++ b/t/src/mpi_version.c
@@ -11,24 +11,28 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#if HAVE_MPI
 #include <mpi.h>
+#endif
 #include <stdio.h>
 
 int main (int argc, char *argv[])
 {
+#if HAVE_MPI
     char version[MPI_MAX_LIBRARY_VERSION_STRING];
     int len;
-    int exit_rc = -1;
 
     MPI_Get_library_version (version, &len);
     if (len < 0) {
         fprintf (stderr, "MPI_Get_library_version failed\n");
-        goto done;
+        return -1;
     }
     printf ("%s\n", version);
-    exit_rc = 0;
-done:
-    return exit_rc;
+    return 0;
+#else
+    fprintf (stderr, "MPI is not configured");
+    return -1;
+#endif
 }
 
 // vi: ts=4 sw=4 expandtab

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -4,10 +4,16 @@ test_description='Test openmpi bootstrap.'
 
 . `dirname $0`/sharness.sh
 
+MPI_VERSION=${FLUX_BUILD_DIR}/t/src/mpi_version
 MPI_HELLO=${FLUX_BUILD_DIR}/t/src/mpi_hello
 MPI_PINGPONG=${FLUX_BUILD_DIR}/t/src/mpi_pingpong
 
 export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
+
+if ! ${MPI_VERSION} >/dev/null 2>&1; then
+    skip_all='skipping openmpi bootstrap tests - MPI unavailable'
+    test_done
+fi
 
 test_under_flux 2
 

--- a/t/t2001-osu-benchmarks.t
+++ b/t/t2001-osu-benchmarks.t
@@ -2,12 +2,17 @@
 
 test_description='Test openmpi with OSU micro benchmarks.'
 
-OSU_MPI=${FLUX_BUILD_DIR}/t/osu-micro-benchmarks/mpi
-
 . `dirname $0`/sharness.sh
+
+MPI_VERSION=${FLUX_BUILD_DIR}/t/src/mpi_version
+OSU_MPI=${FLUX_BUILD_DIR}/t/osu-micro-benchmarks/mpi
 
 export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
 
+if ! ${MPI_VERSION} >/dev/null 2>&1; then
+    skip_all='skipping OSU micro benchmarks - MPI unavailable'
+    test_done
+fi
 if ! test_have_prereq LONGTEST; then
     skip_all='skipping OSU micro benchmarks due to missing LONGTEST prereq'
     test_done

--- a/t/t2002-mpibench.t
+++ b/t/t2002-mpibench.t
@@ -2,14 +2,17 @@
 
 test_description='Test openmpi with mpibench.'
 
-PLUGINPATH=${FLUX_BUILD_DIR}/src/shell/plugins/.libs
+. `dirname $0`/sharness.sh
+
+MPI_VERSION=${FLUX_BUILD_DIR}/t/src/mpi_version
 MPIBENCH="${FLUX_BUILD_DIR}/t/mpibench/mpibench -i5 -C -e1K -m 1M"
 
 export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
 
-. `dirname $0`/sharness.sh
-
-
+if ! ${MPI_VERSION} >/dev/null 2>&1; then
+    skip_all='skipping mpibench tests - MPI unavailable'
+    test_done
+fi
 if ! test_have_prereq LONGTEST; then
     skip_all='skipping mpibench due to missing LONGTEST prereq'
     test_done


### PR DESCRIPTION
Problem: the project cannot be built without openmpi, but it doesn't really depend on it, just a few tests.

Make openmpi optional and skip those tests if it's not configured.

Fix some outdated stuff in the `configure.ac` while we're at it.