### PR TITLE
add PMI client plugin to enable flux to be launched by a pmix server

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ SUBDIRS = \
 	src/common/libutil \
 	src/shell/plugins \
 	src/shell/lua.d \
+	src/upmi \
 	t
 
 EXTRA_DIST = \

--- a/README.md
+++ b/README.md
@@ -1,50 +1,64 @@
 ### flux-pmix
 
-This repo contains a flux shell plugin that is required for bootstrapping
-openmpi v5+ MPI executables.
+This repo adds basic pmix support to Flux.  It contains two main components
+- a Flux shell plugin that adds pmix service to the flux shell for launching
+  some versions of openmpi
+- a Flux PMI client plugin that enables Flux to be launched by a foreign
+  launcher that only supports pmix
 
-The plugin is loaded by requesting it at job submission time with
-the `-ompi=openmpi@5` option.
+The former is loaded by requesting it on the job submission command line, e.g.
+```
+$ flux mini run -ompi=openmpi@5 myprogram
+```
+
+The latter may be selected on the broker command line, e.g.
+```console
+$ jsrun flux start -o,-Sbroker.boot-method=pmix
+```
+
+or by setting the `FLUX_PMI_CLIENT_METHODS` environment variable globally:
+```
+FLUX_PMI_CLIENT_METHODS="simple pmix single"
+```
+
+### installation
 
 Typically this project would be configured with the same `--prefix` as
 flux-core.  If that is not practical, for example in a spack environment,
-then flux can be told to look elsewhere by setting `FLUX_SHELL_RC_PATH`, e.g.
+then flux-shell and flux-broker can be told to look elsewhere for plugins by
+setting, respectively:
 
+```sh
+FLUX_SHELL_RC_PATH=${prefix}/etc/flux/shell/lua.d:$FLUX_SHELL_RC_PATH
+FLUX_PMI_CLIENT_SEARCHPATH=${prefix}/lib/flux/upmi/plugins:$FLUX_PMI_CLIENT_SEARCHPATH
 ```
-FLUX_SHELL_RC_PATH=$prefix/etc/flux/shell/lua.d:$FLUX_SHELL_RC_PATH
-```
-where `$prefix` is the installation prefix of this project.
+where `${prefix}` is the installation prefix of this project.
 
 ### limitations
 
-Clients connect to pmix servers using TCP over IPv4 localhost.  The pmix
-"native" security mechanism is used, which has not been vetted by the Flux
-team.  If in doubt, do not use this plugin when nodes are shared by multiple
-users.
-
-The pmix spec covers a broad range of topics.  Although this plugin is based
-on the openpmix "reference implementation", it only populates callbacks and
-attributes needed to bootstrap some versions of openmpi.  As such, the pmix
+The pmix specs cover a broad range of topics.  Although the shell plugin is
+based on the openpmix "reference implementation", it only populates callbacks
+and attributes needed to bootstrap some versions of openmpi.  As such, the pmix
 interface offered by this plugin should not be used for advanced use cases
 such as: debugger/tool interfaces, process spawn, resource allocation,
 job control, I/O forwarding, process groups, fabric support, storage support,
 event notification, or mpi sessions.
 
-Bootstrap scalability with this plugin is likely to be on par with PMI-1,
+Bootstrap scalability with this plugin is likely to be on par with Flux PMI-1,
 since _fence_ is implemented with the same collective algorithm as PMI-1,
-and the cost of _fence_ will dominate for the larger jobs.  Therefore, we
-currently recommend the well tested PMI-1 default for older openmpi versions.
+and the cost of _fence_ will dominate for the larger jobs.
 
-Although Flux has optional (configure-time) support for being bootstrapped
-by pmix, this plugin will not be used when Flux launches Flux, since the
-Flux broker preferentially chooses PMI-1 over pmix if both are offered, and
-the Flux shell's PMI-1 service is always offered.  In addition, attributes
-required for nesting Flux like `PMI_process_mapping` and `flux.instance-level`
-are not set by this plugin.
+Although Flux can now launch Flux with pmix by combining the two capabilities
+provided by this project, this is not advisable as the Flux pmix server does
+not pre-populate keys that Flux expects to find in the PMI KVS when launched
+in a hierarchy, such as `flux.instance-level` and `flux.taskmap`.
 
 While other MPIs such as mpich and derivatives have optional pmix bootstrap
-support, using pmix to launch them under Flux is neither tested nor expected
-to confer any advantage over the PMI-1 default.
+support, using pmix to launch them under Flux is neither well tested nor
+expected to confer any advantage over the PMI-1 default.
+
+Since the pmix server is embedded in the flux-shell, it is completely
+initialized and torn down for each job, and runs unprivileged as the job owner.
 
 ### license
 

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,9 @@ AC_SUBST(shell_lua_mpidir)
 AS_VAR_SET(shell_plugindir, $libdir/flux/shell/plugins)
 AC_SUBST(shell_plugindir)
 
+AS_VAR_SET(upmi_plugindir, $libdir/flux/upmi/plugins)
+AC_SUBST(upmi_plugindir)
+
 fluxplugin_ldflags="-avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic"
 AC_SUBST(fluxplugin_ldflags)
 
@@ -83,6 +86,7 @@ AC_CONFIG_FILES( \
   src/common/libutil/Makefile \
   src/shell/plugins/Makefile \
   src/shell/lua.d/Makefile \
+  src/upmi/Makefile \
   t/Makefile \
   t/sharness.d/00-setup.sh \
   t/src/Makefile \

--- a/src/upmi/Makefile.am
+++ b/src/upmi/Makefile.am
@@ -1,0 +1,35 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+AM_CPPFLAGS = \
+	-I$(top_srcdir)
+
+
+upmi_plugin_LTLIBRARIES = \
+	pmix.la
+
+pmix_la_SOURCES = \
+	pmix.c
+pmix_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(FLUX_CORE_CFLAGS) \
+	$(FLUX_IDSET_CFLAGS) \
+	$(FLUX_HOSTLIST_CFLAGS) \
+	$(FLUX_TASKMAP_CFLAGS) \
+	$(PMIX_CFLAGS) \
+	$(JANSSON_CFLAGS)
+pmix_la_LIBADD = \
+	$(FLUX_CORE_LIBS) \
+	$(PMIX_LIBS) \
+	$(FLUX_IDSET_LIBS) \
+	$(FLUX_HOSTLIST_LIBS) \
+	$(FLUX_TASKMAP_LIBS) \
+	$(JANSSON_LIBS) \
+	$(top_builddir)/src/common/libccan/libccan.la \
+	$(top_builddir)/src/common/libutil/libutil.la
+pmix_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(fluxplugin_ldflags) \
+	-module

--- a/src/upmi/pmix.c
+++ b/src/upmi/pmix.c
@@ -1,0 +1,242 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* pmix.c - Flux "universal" pmi client plugin
+ *
+ * This implements a pmix client plugin that can be used by flux-broker(1)
+ * for bootstrapping in a foreign environment or by flux-pmi(1) for testing.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdarg.h>
+#include <pmix.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/strlcpy.h"
+
+static const char *plugin_name = "pmix";
+static pmix_proc_t myproc;
+
+/* This function was borrowed from flux-core src/common/libpmi/upmi.c.
+ * External plugins use the public flux "standard plugin" interface only.
+ */
+static void setverror (flux_plugin_t *p,
+                       flux_plugin_arg_t *args,
+                       const char *fmt,
+                       va_list ap)
+{
+    char buf[128];
+
+    (void)vsnprintf (buf, sizeof (buf), fmt, ap);
+    (void)flux_plugin_arg_pack (args,
+                                FLUX_PLUGIN_ARG_OUT,
+                                "{s:s}",
+                                "errmsg", buf);
+}
+
+__attribute__ ((format (printf, 3, 4)))
+static int seterror (flux_plugin_t *p,
+                     flux_plugin_arg_t *args,
+                     const char *fmt,
+                     ...)
+{
+    va_list ap;
+
+    va_start (ap, fmt);
+    setverror (p, args, fmt, ap);
+    va_end (ap);
+    return -1;
+}
+
+/* op_put - store key+value in the kvs
+ * commit is deferred until op_barrier
+ */
+static int op_put (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *data)
+{
+    pmix_status_t rc;
+    pmix_value_t val = { .type = PMIX_STRING };
+    const char *key;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:s s:s}",
+                                "key", &key,
+                                "value", &val.data.string) < 0)
+        return seterror (p, args, "error unpacking put arguments");
+
+    rc = PMIx_Put (PMIX_GLOBAL, key, &val);
+    if (rc != PMIX_SUCCESS)
+        return seterror (p, args, "PMIx_Put: %s", PMIx_Error_string (rc));
+
+    return 0;
+}
+
+/* op_get - retrieve a key+value from kvs
+ * The 'rank' specifies the rank that stored the key, or -1 for keys that
+ * were pre-put by the pmix server.
+ */
+static int op_get (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *data)
+{
+    pmix_proc_t proc;
+    const char *key;
+    int rank;
+    pmix_status_t rc;
+    pmix_value_t *val;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:s s:i}",
+                                "key", &key,
+                                "rank", &rank) < 0)
+        return seterror (p, args, "error unpacking get arguments");
+
+    strlcpy (proc.nspace, myproc.nspace, sizeof (proc.nspace));
+    proc.rank = rank < 0 ? PMIX_RANK_WILDCARD : rank;
+
+    rc = PMIx_Get (&proc, key, NULL, 0, &val);
+    if (rc != PMIX_SUCCESS)
+        return seterror (p, args, "PMIx_Get: %s", PMIx_Error_string (rc));
+    if (val->type != PMIX_STRING || !val->data.string) {
+        PMIX_VALUE_RELEASE (val);
+        return seterror (p, args, "PMIx_Get: wrong value type");
+    }
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:s}",
+                              "value", val->data.string) < 0) {
+        PMIX_VALUE_RELEASE (val);
+        return -1;
+    }
+    PMIX_VALUE_RELEASE (val);
+    return 0;
+}
+
+/* op_barrier - perform exchange of keys put by op_put
+ */
+static int op_barrier (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *data)
+{
+    pmix_status_t rc;
+    pmix_info_t info;
+
+    rc = PMIx_Commit ();
+    if (rc != PMIX_SUCCESS)
+        return seterror (p, args, "PMIx_Commit: %s", PMIx_Error_string (rc));
+
+    memset (&info, 0, sizeof (info));
+    strlcpy (info.key, PMIX_COLLECT_DATA, sizeof (info.key));
+    info.value.type = PMIX_BOOL;
+    info.value.data.flag = true;
+
+    rc = PMIx_Fence (NULL, 0, &info, 1);
+    if (rc!= PMIX_SUCCESS)
+        return seterror (p, args, "PMIx_Fence: %s", PMIx_Error_string (rc));
+
+    return 0;
+}
+
+/* op_initialize - initialize pmix library (e.g. establish connections, start
+ * internal progress thread) and obtain basic parallel program parameters.
+ */
+static int op_initialize (flux_plugin_t *p,
+                          const char *topic,
+                          flux_plugin_arg_t *args,
+                          void *data)
+{
+    pmix_status_t rc;
+    pmix_proc_t proc;
+    pmix_value_t *val;
+
+    rc = PMIx_Init (&myproc, NULL, 0);
+    if (rc != PMIX_SUCCESS)
+        return seterror (p, args, "PMIx_Init: %s", PMIx_Error_string (rc));
+
+    strlcpy (proc.nspace, myproc.nspace, sizeof (proc.nspace));
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &val);
+    if (rc != PMIX_SUCCESS)
+        return seterror (p, args, "PMIx_Get size: %s", PMIx_Error_string (rc));
+    if (val->type != PMIX_UINT32) {
+        PMIX_VALUE_RELEASE (val);
+        return seterror (p, args, "PMIx_Get size: wrong type");
+    }
+
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:i s:s s:i}",
+                              "rank", myproc.rank,
+                              "name", myproc.nspace,
+                              "size", val->data.uint32) < 0) {
+        PMIX_VALUE_RELEASE (val);
+        return -1;
+    }
+    PMIX_VALUE_RELEASE (val);
+    return 0;
+}
+
+/* op_finalize - finalize the pmix library (drop connections, stop thread)
+ */
+static int op_finalize (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_Finalize (NULL, 0);
+    if (rc != PMIX_SUCCESS)
+        return seterror (p, args, "%s",  PMIx_Error_string (rc));
+
+    return 0;
+}
+
+/* op_preinit - probe the environment for clues that pmix should be used.
+ * N.B. we could attach a local context to the flux_plugin_t object here if
+ * needed.  For now 'myproc' is global.
+ */
+static int op_preinit (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *data)
+{
+    if (!getenv ("PMIX_SERVER_URI") && !getenv ("PMIX_SERVER_URI2"))
+        return seterror (p, args, "PMIX_SERVER_URI* not found in environment");
+    return 0;
+}
+
+static const struct flux_plugin_handler optab[] = {
+    { "upmi.put",           op_put,         NULL },
+    { "upmi.get",           op_get,         NULL },
+    { "upmi.barrier",       op_barrier,     NULL },
+    { "upmi.initialize",    op_initialize,  NULL },
+    { "upmi.finalize",      op_finalize,    NULL },
+    { "upmi.preinit",       op_preinit,     NULL },
+    { 0 },
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_register (p, plugin_name, optab) < 0)
+        return -1;
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -34,6 +34,7 @@ TESTSCRIPTS = \
 	t0005-abort.t \
 	t0006-notify.t \
 	t0007-dmodex.t \
+	t0008-upmi.t \
 	t1000-ompi-basic.t \
 	t2001-osu-benchmarks.t \
 	t2002-mpibench.t

--- a/t/t0008-upmi.t
+++ b/t/t0008-upmi.t
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+test_description='Check out libupmi pmix plugin.'
+
+. `dirname $0`/sharness.sh
+
+VERSION=${FLUX_BUILD_DIR}/t/src/version
+export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
+
+# N.B. this also affects the test_under_flux broker bootstrap,
+# so be sure 'simple' comes first so the broker finds flux-start's pmi server
+export FLUX_PMI_CLIENT_METHODS="simple pmix libpmi single"
+export FLUX_PMI_CLIENT_SEARCHPATH=${FLUX_BUILD_DIR}/src/upmi/.libs
+
+test_under_flux 2
+
+# broker.boot-method was added with upmi dso plugin support
+if ! flux getattr broker.boot-method; then
+    skip_all='skipping upmi tests - flux lacks external upmi plugin support'
+    test_done
+fi
+
+test_expect_success 'print pmix library version' '
+	${VERSION}
+'
+
+test_expect_success '1n2p barrier works and selected pmix' '
+	run_timeout 30 flux mini run -opmi=off -N1 -n2 --label-io \
+		flux pmi -v barrier 2>1n2p-barrier.err &&
+	grep "1: pmix: barrier: success" 1n2p-barrier.err
+'
+
+test_expect_success '2n2p barrier works' '
+	run_timeout 30 flux mini run -opmi=off -N2 -n2 --label-io \
+		flux pmi -v barrier
+'
+
+test_expect_success '2n3p barrier works' '
+	run_timeout 30 flux mini run -opmi=off -N2 -n3 --label-io \
+		flux pmi -v barrier
+'
+
+test_expect_success '2n4p barrier works' '
+	run_timeout 30 flux mini run -opmi=off -N2 -n4 --label-io \
+		flux pmi -v barrier
+'
+
+test_expect_success '1n2p exchange works' '
+	run_timeout 30 flux mini run -opmi=off -N1 -n2 --label-io \
+		flux pmi -v exchange
+'
+
+test_expect_success '2n4p exchange works' '
+	run_timeout 30 flux mini run -opmi=off -N2 -n4 --label-io \
+		flux pmi -v exchange
+'
+test_expect_success 'get of unknown key fails' '
+	test_must_fail flux mini run -opmi=off \
+		flux pmi -v get notakey
+'
+test_expect_success 'flux launches flux with pmi' '
+	cat >method.exp <<-EOT &&
+	pmix
+	EOT
+	flux mini run -opmi=off \
+		flux start flux getattr broker.boot-method >method.out &&
+	test_cmp method.exp method.out
+'
+
+test_done


### PR DESCRIPTION
flux-framework/flux-core#4865 enables broker bootstrap methods to be provided by dso plugins and drops pmix client support from the broker.  This PR re-adds support by providing a dso.

This seems better since it localizes the openpmix dependency here.