### PR TITLE
clear PMIX_ environment variables in broker

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -10,4 +10,6 @@ AM_CPPFLAGS =
 noinst_LTLIBRARIES = libutil.la
 libutil_la_SOURCES = \
 	strlcpy.c \
-	strlcpy.h
+	strlcpy.h \
+	unsetenv_glob.c \
+	unsetenv_glob.h

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -5,7 +5,8 @@ AM_CFLAGS = \
 AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
-AM_CPPFLAGS =
+AM_CPPFLAGS = \
+	-I$(top_srcdir)
 
 noinst_LTLIBRARIES = libutil.la
 libutil_la_SOURCES = \
@@ -13,3 +14,22 @@ libutil_la_SOURCES = \
 	strlcpy.h \
 	unsetenv_glob.c \
 	unsetenv_glob.h
+
+TESTS =	test_unsetenv_glob.t
+
+test_ldadd = \
+	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/libtap/libtap.la
+test_cppflags = \
+	-I$(top_srcdir)/src/common/libtap \
+	$(AM_CPPFLAGS)
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
+test_unsetenv_glob_t_SOURCES = test/unsetenv_glob.c
+test_unsetenv_glob_t_CPPFLAGS = $(test_cppflags)
+test_unsetenv_glob_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/test/unsetenv_glob.c
+++ b/src/common/libutil/test/unsetenv_glob.c
@@ -1,0 +1,50 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+
+#include "tap.h"
+#include "src/common/libutil/unsetenv_glob.h"
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    if (setenv ("ENVGLOB_A", "x", 1) < 0
+        || setenv ("ENVGLOB_B", "x", 1) < 0
+        || setenv ("ENVGLOB_BB", "x", 1) < 0
+        || setenv ("ENVGLOB_C", "x", 1) < 0)
+        BAIL_OUT ("unable to set test env vars");
+
+    ok (unsetenv_glob ("ENVGLOB_A") == 1,
+        "unsetenv_glob with non-glob pattern works");
+    ok (!getenv ("ENVGLOB_A"),
+        "target variable is unset");
+    ok (getenv ("ENVGLOB_B") && getenv ("ENVGLOB_BB") && getenv ("ENVGLOB_C"),
+        "non-target variables remain set");
+
+    ok (unsetenv_glob ("ENVGLOB_B*") == 2,
+        "unsetenv_glob wtih glob pattern works");
+    ok (!getenv ("ENVGLOB_B") && !getenv ("ENVGLOB_BB"),
+        "target variables are unset");
+    ok (getenv ("ENVGLOB_C") != NULL,
+        "non-target variable remains set");
+
+    ok (unsetenv_glob ("") == 0,
+        "unsetenv_glob pattern=\"\" returns 0");
+    errno = 0;
+    ok (unsetenv_glob (NULL) < 0,
+        "unsetenv_glob NULL fails with EINVAL");
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/unsetenv_glob.c
+++ b/src/common/libutil/unsetenv_glob.c
@@ -1,0 +1,96 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* unsetenv_glob.c - unset environment variables matching a glob pattern
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <argz.h>
+#include <envz.h>
+#include <fnmatch.h>
+#include <errno.h>
+
+extern char **environ;
+
+static char *split (const char *s, int delim)
+{
+    char *key, *val;
+
+    if (!(key = strdup (s)))
+        return NULL;
+    if ((val = strchr (key, delim)))
+        *val++ = '\0';
+    return key;
+}
+
+static int unsetenv_glob_entry (const char *entry, const char *pattern)
+{
+    char *name;
+    int rc;
+    int count = 0;
+    int saved_errno;
+
+    if (!(name = split (entry, '=')))
+        goto error;
+    rc = fnmatch (pattern, name, 0);
+    if (rc != 0 && rc != FNM_NOMATCH) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (rc == 0) {
+        if (unsetenv (name) < 0)
+            goto error;
+        count++;
+    }
+    free (name);
+    return count;
+error:
+    saved_errno = errno;
+    free (name);
+    errno = saved_errno;
+    return -1;
+}
+
+int unsetenv_glob (const char *pattern)
+{
+    char *envz = NULL;
+    size_t envz_len = 0;
+    const char *entry;
+    int count = 0;
+    int rc;
+
+    if (pattern == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (argz_create (environ, &envz, &envz_len) != 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    entry = argz_next (envz, envz_len, NULL);
+    while (entry) {
+        rc = unsetenv_glob_entry (entry, pattern);
+        if (rc < 0) {
+            int saved_errno = errno;
+            free (envz);
+            errno = saved_errno;
+            return -1;
+        }
+        count += rc;
+        entry = argz_next (envz, envz_len, entry);
+    }
+    free (envz);
+    return count;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/unsetenv_glob.h
+++ b/src/common/libutil/unsetenv_glob.h
@@ -1,0 +1,19 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UNSETENV_GLOB_H
+#define _UNSETENV_GLOB_H
+
+int unsetenv_glob (const char *pattern);
+
+#endif // !_UNSETENV_GLOB_H
+
+// vi:ts=4 sw=4 expandtab
+

--- a/t/t0008-upmi.t
+++ b/t/t0008-upmi.t
@@ -58,7 +58,7 @@ test_expect_success 'get of unknown key fails' '
 	test_must_fail flux mini run -opmi=off \
 		flux pmi -v get notakey
 '
-test_expect_success 'flux launches flux with pmi' '
+test_expect_success 'flux launches flux with pmix' '
 	cat >method.exp <<-EOT &&
 	pmix
 	EOT

--- a/t/t0008-upmi.t
+++ b/t/t0008-upmi.t
@@ -66,5 +66,13 @@ test_expect_success 'flux launches flux with pmix' '
 		flux start flux getattr broker.boot-method >method.out &&
 	test_cmp method.exp method.out
 '
+test_expect_success 'flux blocks PMIX_ prefixed environment variables' '
+	cat >method.exp <<-EOT &&
+	pmix
+	EOT
+	flux mini run -opmi=off \
+		flux start printenv >blockenv.out &&
+	test_must_fail grep "^PMIX_" blockenv.out
+'
 
 test_done


### PR DESCRIPTION
Ensure that the flux pmix client plugin  (upmi) clears PMIX_* environment variables after finalize is called, so that these variables don't leak through to Flux jobs.