### PR TITLE
require flux-core 0.49.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,6 @@ or by setting the `FLUX_PMI_CLIENT_METHODS` environment variable globally:
 FLUX_PMI_CLIENT_METHODS="simple pmix single"
 ```
 
-### installation
-
-Typically this project would be configured with the same `--prefix` as
-flux-core.  If that is not practical, for example in a spack environment,
-then flux-shell and flux-broker can be told to look elsewhere for plugins by
-setting, respectively:
-
-```sh
-FLUX_SHELL_RC_PATH=${prefix}/etc/flux/shell/lua.d:$FLUX_SHELL_RC_PATH
-FLUX_PMI_CLIENT_SEARCHPATH=${prefix}/lib/flux/upmi/plugins:$FLUX_PMI_CLIENT_SEARCHPATH
-```
-where `${prefix}` is the installation prefix of this project.
-
 ### limitations
 
 The pmix specs cover a broad range of topics.  Although the shell plugin is

--- a/config/ax_flux_core.m4
+++ b/config/ax_flux_core.m4
@@ -51,7 +51,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH}
   export PKG_CONFIG_PATH
 
-  PKG_CHECK_MODULES([FLUX_CORE], [flux-core >= 0.46.0],
+  PKG_CHECK_MODULES([FLUX_CORE], [flux-core >= 0.49.0],
     [
       FLUX_PREFIX=`pkg-config --variable=prefix flux-core`
       LIBFLUX_VERSION=`pkg-config --modversion flux-core`


### PR DESCRIPTION
Problem: the minimum flux-core version required by configure is wrong.

Raise the minimum version to 0.49.0.

Also drop the installation section from the README.md since it's out of date and probably not needed anyway.