### PR TITLE
ci: remove el7 build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: "focal - ompi v5.0.x"
+        - name: "focal - ompi v5.0.x, chain_lint"
           image: "focal"
-          ompi_branch: "v5.0.x"
-          openpmix_branch: "v4.2.3"
-          coverage: false
-          env: {}
-        - name: "el7 - ompi v5.0.x, chain_lint"
-          image: "el7"
           ompi_branch: "v5.0.x"
           openpmix_branch: "v4.2.3"
           coverage: false


### PR DESCRIPTION
Problem: The el7 flux-core docker image will no longer be updated because it is being dropped from the matrix of test images in CI.

Drop the el7 build in flux-pmix CI as well. Move chain_lint=t to another builder so that at least one build continues to run with --chain-lint.