### PR TITLE
plugin: use a simpler strategy for the interthread channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,14 @@ jobs:
         include:
         - name: "focal - ompi v5.0.x, chain_lint"
           image: "focal"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc12"
           openpmix_branch: "v4.2.3"
           coverage: false
           env:
             chain_lint: t
         - name: "el8 - ompi v5.0.x, distcheck"
           image: "el8"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc12"
           openpmix_branch: "v4.2.3"
           coverage: false
           env:
@@ -44,14 +44,14 @@ jobs:
           env: {}
         - name: "coverage"
           image: "focal"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc12"
           openpmix_branch: "v4.2.3"
           coverage: true
           env:
             COVERAGE: t
         - name: "fedora34 - ompi v5.0.x"
           image: "fedora34"
-          ompi_branch: "v5.0.x"
+          ompi_branch: "v5.0.0rc12"
           openpmix_branch: "v4.2.3"
           coverage: false
           env: {}


### PR DESCRIPTION
Problem: recent changes in flux-core have made the `shmem://` connector less convenient to use, and broke flux-pmix.

This swaps out the back-to-back `flux_t` handles, used for sending messages from the pmix server thread to the shell thread, for a `struct flux_msglist` protected by mutexes.  This should work with all recent flux-core versions, and doesn't require the flux shell to take on a zeromq context, which brings with it some potential issues.

Also CI is updated to build ompi 5.0.0rc12 rather than the 5.0.x development branch, which was failing.  We'll deal with getting CI back to tracking upstream 5.0.x development later.