### PR TITLE
plugin: pmix notification encoding problems

### DIFF
--- a/src/shell/plugins/codec.c
+++ b/src/shell/plugins/codec.c
@@ -404,6 +404,7 @@ int codec_info_decode (json_t *o, pmix_info_t *info)
         return -1;
     if (codec_value_decode (xvalue, &info->value) < 0) // allocs mem
         return -1;
+    info->flags = flags;
     strlcpy (info->key, key, sizeof (info->key));
     info->key[PMIX_MAX_KEYLEN] = '\0';
     return 0;

--- a/src/shell/plugins/codec.h
+++ b/src/shell/plugins/codec.h
@@ -28,7 +28,7 @@ json_t *codec_value_encode (const pmix_value_t *value);
 int codec_value_decode (json_t *o, pmix_value_t *value); // allocs internal mem
 void codec_value_release (pmix_value_t *value); // free internal mem from decode
 
-json_t *code_info_encode (const pmix_info_t *info);
+json_t *codec_info_encode (const pmix_info_t *info);
 int codec_info_decode (json_t *o, pmix_info_t *info); // allocs internal mem
 void codec_info_release (pmix_info_t *info); // free internal mem from decode
 

--- a/src/shell/plugins/notify.c
+++ b/src/shell/plugins/notify.c
@@ -61,7 +61,7 @@ static void notify_shell_cb (const flux_msg_t *msg, void *arg)
     const char *message = NULL;
 
     if (flux_msg_unpack (msg,
-                         "{s:o s:i s:o s:o s:o s:o s:o}",
+                         "{s:i s:i s:o s:o s:o s:o s:o}",
                          "id", &id,
                          "status", &status,
                          "source", &xsource,


### PR DESCRIPTION
Problem: at one point while working on #89, `t0006-notify.t` began segfaulting.  The segfault disappeared in the eventual solution to #89, however there really was a bug there causing stack corruption.

Fix two problems with message encoding for pmix notifications, and improve unit tests for codec.c.
