### PR TITLE
ci:  add fedora40 and el9 builders

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         - name: "el8 - ompi v4.1.4"
           image: "el8"
           ompi_branch: "v4.1.4"
-          openpmix_branch: "v3.2.3"
+          openpmix_branch: "v3.2.5"
           coverage: false
           env: {}
         - name: "jammy - coverage"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,8 @@ jobs:
           coverage: true
           env:
             COVERAGE: t
-        - name: "fedora34 - ompi v5.0.6"
-          image: "fedora34"
+        - name: "fedora40 - ompi v5"
+          image: "fedora40"
           ompi_branch: "v5.0.6"
           openpmix_branch: "v4.2.9"
           coverage: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,12 @@ jobs:
           openpmix_branch: "v4.2.9"
           coverage: false
           env: {}
+        - name: "el9 - ompi v5"
+          image: "el9"
+          ompi_branch: "v5.0.6"
+          openpmix_branch: "v4.2.9"
+          coverage: false
+          env: {}
         - name: "jammy - ompi v4.1.x"
           image: "jammy"
           ompi_branch: "v4.1.x"

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -3,7 +3,7 @@ FROM fluxrm/flux-core:el8
 ARG USER=fluxuser
 ARG UID=1000
 ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.2.2
+ARG OPENPMIX_BRANCH=v4.2.9
 
 RUN \
  if test "$USER" != "fluxuser"; then  \

--- a/src/test/docker/el9/Dockerfile
+++ b/src/test/docker/el9/Dockerfile
@@ -1,0 +1,57 @@
+FROM fluxrm/flux-core:el9
+
+ARG USER=fluxuser
+ARG UID=1000
+ARG OMPI_BRANCH=v5.0.x
+ARG OPENPMIX_BRANCH=v4.2.9
+
+RUN \
+ if test "$USER" != "fluxuser"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER \
+   && sudo usermod -G wheel fluxuser ; \
+ fi
+
+# install ompi prereqs
+RUN sudo yum -y update \
+ && sudo yum -y install \
+    libevent-devel \
+    zlib-devel \
+ && sudo yum -y remove mpich mpich-devel \
+ && sudo yum clean all
+
+ # build/install openpmix
+RUN cd /tmp \
+ && git clone -b ${OPENPMIX_BRANCH} \
+      --recursive --depth=1 https://github.com/openpmix/openpmix \
+ && cd openpmix \
+ && git branch \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --enable-debug --disable-sphinx \
+ && make -j $(nproc) \
+ && sudo rm -rf /usr/lib64/pmix \
+ && sudo make install \
+ && cd .. \
+ && rm -rf openpmix
+
+# build/install ompi
+RUN cd /tmp \
+ && git clone -b ${OMPI_BRANCH} \
+      --recursive --depth=1 https://github.com/open-mpi/ompi \
+ && cd ompi \
+ && git branch \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr \
+      --disable-man-pages --enable-debug --enable-mem-debug \
+      --with-pmix=external --with-libevent --disable-sphinx \
+ && make -j $(nproc) \
+ && sudo make install \
+ && cd .. \
+ && rm -rf ompi
+
+USER $USER
+WORKDIR /home/$USER
+

--- a/src/test/docker/fedora40/Dockerfile
+++ b/src/test/docker/fedora40/Dockerfile
@@ -1,9 +1,9 @@
-FROM fluxrm/flux-core:fedora34
+FROM fluxrm/flux-core:fedora40
 
 ARG USER=fluxuser
 ARG UID=1000
 ARG OMPI_BRANCH=v5.0.x
-ARG OPENPMIX_BRANCH=v4.2.2
+ARG OPENPMIX_BRANCH=v4.2.9
 
 RUN \
  if test "$USER" != "fluxuser"; then  \
@@ -20,7 +20,7 @@ RUN sudo yum -y update \
     flex \
     libevent-devel \
     zlib-devel \
- && sudo yum -y remove mpich mpich-devel \
+ && sudo yum -y remove mpich mpich-devel pmix pmix-devel \
  && sudo yum clean all
 
  # build/install openpmix


### PR DESCRIPTION
Problem: ci is building fedora34, which isn't being updated anymore in flux-core.  Also ci is missing an el9 builder.

Add  an el9 builder and update fedora34 to fedora40.