### PR TITLE
build: fix compilation on el9 with older pmix releases

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,16 @@ AS_CASE($ax_cv_c_compiler_vendor,
     WARNING_CFLAGS="-Wall -Werror -Wno-strict-aliasing -Wno-error=deprecated-declarations"
   ]
 )
+saved_CFLAGS="$CFLAGS"
+CFLAGS="-Wstringop-overread $CFLAGS"
+AC_MSG_CHECKING([whether compiler accepts -Wstringop-overread])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [
+  AC_MSG_RESULT([yes])
+  WARNING_CFLAGS="$WARNING_CFLAGS -Wno-error=stringop-overread"
+  ],[
+  AC_MSG_RESULT([no])
+])
+CFLAGS="$saved_CFLAGS"
 AC_SUBST([WARNING_CFLAGS])
 
 LT_INIT


### PR DESCRIPTION
Problem: compilation fails in the TOSS 5 build farm with pmix-3.2.5.

pmix.c: In function 'op_initialize.part.0':
pmix.c:175:10: error: 'PMIx_Get' reading 512 bytes from a region of size 14 [-Werror=stringop-overread]
  175 |     rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &val);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pmix.c:175:10: note: referencing argument 2 of type 'const char *'
In file included from pmix.c:21:
/usr/include/pmix.h:203:27: note: in a call to function 'PMIx_Get'
  203 | PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key,
      |                           ^~~~~~~~
cc1: all warnings being treated as errors

This is probably due to the fact that PMIx_Get() in pmix-3.2.5 is prototyped with the second arg effectively 'const char key[512]'. It is declared as a 'const char key[]' in modern pmix releases.

Since PMIx_Get() is used in more than one place, disable the promotion of that warning to an error project-wide.

Fixes #100