### PR TITLE
shell: add the infovec_set_byte_object_new() subroutine

### DIFF
--- a/src/shell/plugins/infovec.c
+++ b/src/shell/plugins/infovec.c
@@ -173,6 +173,26 @@ int infovec_set_infovec_new (struct infovec *iv,
     return 0;
 }
 
+int infovec_set_byte_object_new (struct infovec *iv,
+                                 const char *key,
+                                 void *value,
+                                 size_t size)
+{
+    pmix_info_t *info;
+
+    if (!iv || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strlcpy (info->key, key, sizeof (info->key));
+    info->value.type = PMIX_BYTE_OBJECT;
+    info->value.data.bo.bytes = value;
+    info->value.data.bo.size = size;
+    return 0;
+}
+
 int infovec_count (struct infovec *iv)
 {
     return iv->count;
@@ -198,6 +218,9 @@ static void destroy_info_array (pmix_info_t *info, int count)
                                             value->data.darray->size);
                         free (value->data.darray);
                     }
+                    break;
+                case PMIX_BYTE_OBJECT:
+                    free (value->data.bo.bytes);
                     break;
             }
         }

--- a/src/shell/plugins/infovec.h
+++ b/src/shell/plugins/infovec.h
@@ -22,6 +22,10 @@ int infovec_set_str (struct infovec *iv, const char *key, const char *str);
 int infovec_set_str_new (struct infovec *iv, const char *key, char *str);
 int infovec_set_bool (struct infovec *iv, const char *key, bool val);
 int infovec_set_rank (struct infovec *iv, const char *key, pmix_rank_t val);
+int infovec_set_byte_object_new (struct infovec *iv,
+                                 const char *key,
+                                 void *value,
+                                 size_t size);
 int infovec_set_infovec_new (struct infovec *iv,
                              const char *key,
                              struct infovec *val);

--- a/src/shell/plugins/test/infovec.c
+++ b/src/shell/plugins/test/infovec.c
@@ -126,6 +126,24 @@ void basic (void)
     ok (info[3].value.data.rank == PMIX_RANK_WILDCARD,
         "value data is set correctly");
 
+    /* byte object */
+    char * bo_bytes = strdup("blob");
+    size_t bo_size = strlen(bo_bytes) + 1;
+    ok (infovec_set_byte_object_new (iv, "blo", bo_bytes, bo_size) == 0,
+        "infovec_set_byte_object_new blo=blog works");
+    ok (infovec_count (iv) == 5,
+        "infovec_count returns 5");
+    info = infovec_info (iv);
+    ok (strcmp (info[4].key, "blo") == 0,
+        "key is set correctly");
+    ok (info[4].value.type == PMIX_BYTE_OBJECT,
+        "value type is set correctly");
+    ok (info[4].value.data.bo.size == bo_size,
+        "size is set correctly");
+    ok (info[4].value.data.bo.bytes != NULL
+        && memcmp (info[4].value.data.bo.bytes, bo_bytes, bo_size) == 0,
+        "bytes are set correctly");
+
     infovec_destroy (iv);
 }
 


### PR DESCRIPTION
That subroutine adds a previously malloc'ed PMIX_BYTE_OBJECT info. The info will be free'd when destroy_info_array() is invoked.