### PR TITLE
repo: add LICENSE to release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ SUBDIRS = \
 	t
 
 EXTRA_DIST = \
+	LICENSE \
 	NEWS.md \
 	README.md \
 	NOTICE.LLNS \


### PR DESCRIPTION
Problem: LICENSE file is not currently included in release tarballs

Add it by listing it in EXTRA_DIST in the top-level Makefile.am