### PR TITLE
 WiP: Add basic communication mechanism for dynamic allocations via PMIx

### DIFF
--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -30,7 +30,9 @@ pmix_la_SOURCES = \
 	notify.h \
 	notify.c \
 	dmodex.h \
-	dmodex.c
+	dmodex.c \
+	alloc.h \
+	alloc.c
 pmix_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_CORE_CFLAGS) \

--- a/src/shell/plugins/alloc.c
+++ b/src/shell/plugins/alloc.c
@@ -1,0 +1,183 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* alloc.c - handle alloc callback from openpmix server
+ *
+ * User calls PMIx_Allocation_request (directive, info, ninfo, results, nresults);
+ *
+ * This is forwarded to the scheduler.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <pmix.h>
+#include <pmix_server.h>
+
+#include "codec.h"
+#include "interthread.h"
+
+#include "alloc.h"
+
+struct alloc {
+    flux_shell_t *shell;
+    struct interthread *it;
+    int trace_flag;
+};
+
+struct alloc_caddy_t {
+    pmix_info_t *results;
+    size_t nresults;
+    pmix_info_cbfunc_t cbfunc;
+    void *cbdata;
+};
+
+/* This is for the benefit of server callbacks that don't have
+ * a way to be passed a user-supplied opaque pointer.
+ */
+static struct alloc *global_alloc_ctx;
+
+void pmix_release_cbfunc (void *data){
+    struct alloc_caddy_t *alloc_caddy = (struct alloc_caddy_t *) data;
+    if(0 < alloc_caddy->nresults) {
+        PMIX_INFO_FREE(alloc_caddy->results, alloc_caddy->nresults);
+    }
+    free(alloc_caddy);
+}
+
+/* Receives REQUEST for dynamic allocation from pmix_server thread.
+ * TODO: Forward REQUEST to shell
+ * For now, we immediately send a RESPONSE back to the client
+ */
+static void alloc_shell_cb (const flux_msg_t *msg, void *arg)
+{
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    json_t *xdata = NULL;
+    pmix_alloc_directive_t directive;
+    pmix_info_t *data;
+    size_t ndata;
+    pmix_info_cbfunc_t cbfunc;
+    void *cbdata;
+    const char *nspace;
+    int rank;
+
+    struct alloc_caddy_t *alloc_caddy;
+
+    shell_debug("handling allocation request");
+
+    if(0 > flux_msg_unpack (msg,
+                         "{s:s s:i s:i s:O s:O s:O}",
+                         "nspace", &nspace,
+                         "rank", &rank,
+                         "directive", &directive,
+                         "data", &xdata,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata)
+            || 0 > codec_info_array_decode (xdata, &data, &ndata)
+            || 0 > codec_pointer_decode (xcbfunc, (void **)&cbfunc)
+            || 0 > codec_pointer_decode (xcbdata, &cbdata)){
+        shell_warn ("error unpacking interthread alloc_upcall message");
+        return;
+    }
+
+    /* TODO: Once flux shell supports dynamic allocations, forward to shell 0.
+     * For now, just echo back the provided attriutes to the client.
+     */
+    alloc_caddy = malloc(sizeof(struct alloc_caddy_t));
+    alloc_caddy->results = data;
+    alloc_caddy->nresults = ndata;
+    alloc_caddy->cbfunc = cbfunc;
+    alloc_caddy->cbdata = cbdata;
+
+    if(NULL != alloc_caddy->cbfunc){
+        shell_debug("calling back into PMIx server with alloc response");
+        alloc_caddy->cbfunc(PMIX_SUCCESS,
+                            alloc_caddy->results,
+                            alloc_caddy->nresults,
+                            alloc_caddy->cbdata,
+                            pmix_release_cbfunc,
+                            (void *) alloc_caddy);
+    }
+    shell_debug("done handling allocation request from client %s:%d\n", nspace, rank);
+}
+
+
+/* Recives REQUEST for dynamic allocation request from client.
+ * Forwards REQUEST to shell thread
+ */
+int alloc_server_cb (const pmix_proc_t *client,
+                    pmix_alloc_directive_t directive,
+                    const pmix_info_t data[], size_t ndata,
+                    pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    struct alloc *alloc = global_alloc_ctx;
+    json_t *xdata = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    int rc = PMIX_SUCCESS;
+
+    shell_debug("recived allocation request from %s:%d", client->nspace, client->rank);
+
+    if (!(xdata = codec_info_array_encode (data, ndata))
+        || !(xcbfunc = codec_pointer_encode (cbfunc))
+        || !(xcbdata = codec_pointer_encode (cbdata))
+        || interthread_send_pack (alloc->it,
+                                  "alloc_upcall",
+                                  "{s:s s:i s:i s:O s:O s:O}",
+                                  "nspace", client->nspace,
+                                  "rank", client->rank,
+                                  "directive", directive,
+                                  "data", xdata,
+                                  "cbfunc", xcbfunc,
+                                  "cbdata", xcbdata) < 0) {
+        fprintf (stderr, "error sending alloc_upcall interthread message\n");
+        rc = PMIX_ERROR;
+    }
+    json_decref (xdata);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+
+    shell_debug("shifting thread to handle allocation request");
+
+    return rc;
+}
+
+void alloc_destroy (struct alloc *alloc)
+{
+    if (alloc) {
+        int saved_errno = errno;
+        free (alloc);
+        errno = saved_errno;
+        global_alloc_ctx = NULL;
+    }
+}
+
+struct alloc *alloc_create (flux_shell_t *shell, struct interthread *it)
+{
+    struct alloc *alloc;
+
+
+    if (!(alloc = calloc (1, sizeof (*alloc))))
+        return NULL;
+    alloc->shell = shell;
+    alloc->it = it;
+    alloc->trace_flag = 1; // stuck on for now
+    if (interthread_register (it, "alloc_upcall", alloc_shell_cb, alloc) < 0)
+        goto error;
+    global_alloc_ctx = alloc;
+    return alloc;
+error:
+    alloc_destroy (alloc);
+    return NULL;
+}

--- a/src/shell/plugins/alloc.h
+++ b/src/shell/plugins/alloc.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PX_ALLOC_H
+#define _PX_ALLOC_H
+
+#include <pmix.h>
+#include <pmix_server.h>
+#include "interthread.h"
+
+/* Create context that allows alloc_server_cb() to work.
+ * N.B. ensure pmix thread is not running when create/destroy are called.
+ */
+struct alloc *alloc_create (flux_shell_t *shell, struct interthread *it);
+void alloc_destroy (struct alloc *alloc);
+
+/* Server alloc callback registered with PMIx_server_init().
+ */
+int alloc_server_cb (const pmix_proc_t *client,
+                    pmix_alloc_directive_t directive,
+                    const pmix_info_t data[], size_t ndata,
+                    pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+#endif // _PX_ALLOC_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/codec.c
+++ b/src/shell/plugins/codec.c
@@ -216,6 +216,9 @@ json_t *codec_value_encode (const pmix_value_t *value)
         case PMIX_UINT64:
             data = json_integer (value->data.uint64);
             break;
+        case PMIX_ALLOC_DIRECTIVE:
+            data = json_integer (value->data.adir);
+            break;
         case PMIX_PROC_RANK:
             data = json_integer (value->data.rank);
             break;

--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -35,6 +35,7 @@
 #include "abort.h"
 #include "notify.h"
 #include "dmodex.h"
+#include "alloc.h"
 
 struct px {
     flux_shell_t *shell;
@@ -50,6 +51,7 @@ struct px {
     struct abort *abort;
     struct notify *notify;
     struct dmodex *dmodex;
+    struct alloc *alloc;
 };
 
 static pmix_server_module_t server_callbacks;
@@ -261,6 +263,11 @@ static int px_init (flux_plugin_t *p,
         return -1;
     }
     server_callbacks.direct_modex = dmodex_server_cb;
+    if (!(px->alloc = alloc_create (shell, px->it))) {
+        shell_log_error ("could not create alloc handler");
+        return -1;
+    }
+    server_callbacks.allocate = alloc_server_cb;
 
     strlcpy (info[0].key, PMIX_SERVER_TMPDIR, sizeof (info[0].key));
     info[0].value.type = PMIX_STRING;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -35,6 +35,7 @@ TESTSCRIPTS = \
 	t0006-notify.t \
 	t0007-dmodex.t \
 	t0008-upmi.t \
+	t0009-alloc.t \
 	t1000-ompi-basic.t \
 	t2001-osu-benchmarks.t \
 	t2002-mpibench.t

--- a/t/src/Makefile.am
+++ b/t/src/Makefile.am
@@ -13,6 +13,7 @@ AM_CPPFLAGS = \
 	$(PMIX_CFLAGS)
 
 check_PROGRAMS = \
+	alloc \
 	barrier \
 	bizcard \
 	version \
@@ -43,6 +44,9 @@ test_ldadd = \
 	$(FLUX_IDSET_LIBS) \
 	$(OMPI_LIBS) \
 	$(PMIX_LIBS)
+
+alloc_SOURCES = alloc.c
+alloc_LDADD = $(test_ldadd)
 
 barrier_SOURCES = barrier.c
 barrier_LDADD = $(test_ldadd)

--- a/t/src/alloc.c
+++ b/t/src/alloc.c
@@ -1,0 +1,54 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+/* alloc.c - call PMIx_Allocation_request()
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "pmix.h"
+
+int main(int argc, char *argv[]){
+    int rc;
+    size_t nresults;
+    pmix_proc_t myproc;
+    pmix_info_t *info, *results;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))){
+        fprintf(stderr, "Error in PMIx_Init: %d\n", rc);
+        return 1;
+    }
+
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], "test", "test", PMIX_STRING);
+    printf("Client ns %s rank %d sending allocation request to PMIx server\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS
+        != (rc = PMIx_Allocation_request(PMIX_ALLOC_NEW, info, 1, &results, &nresults))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Allocation_request_nb failed: %d\n",
+                myproc.nspace, myproc.rank, rc);
+        PMIX_INFO_FREE(info, 1);
+        return 1;
+    }
+    for(int n = 0; n < nresults; n++){
+        if(results[n].value.type == PMIX_STRING){
+            printf("Client recevived allocation result[%d] %s -> %s\n", n, results[n].key, results[n].value.data.string);
+        }
+    }
+    PMIX_INFO_FREE(info, 1);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))){
+        fprintf(stderr, "Error in PMIx_Finalize: %d\n", rc);
+        return 1;
+    }
+
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t0009-alloc.t
+++ b/t/t0009-alloc.t
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+test_description='Exercise empty alloc.'
+
+. `dirname $0`/sharness.sh
+
+ALLOC=${FLUX_BUILD_DIR}/t/src/alloc
+VERSION=${FLUX_BUILD_DIR}/t/src/version
+export FLUX_SHELL_RC_PATH=${FLUX_BUILD_DIR}/t/etc
+
+test_under_flux 2
+
+test_expect_success 'print pmix library version' '
+	${VERSION}
+'
+
+# Single-shell barriers do not trigger fence server upcall,
+# so the 1n2p tests are just checking openpmix behavior
+
+test_expect_success 'alloc works' '
+	run_timeout 30 flux run -o verbose=3 \
+		${ALLOC}
+'
+
+test_done


### PR DESCRIPTION
This pull request adds an implementation of the PMIx_Allocation_request API that builds on top of the corresponding pull request in flux-core: https://github.com/flux-framework/flux-core/pull/7677. Comments and suggestions are welcome.

The complete communication mechanism is illustrated by the figure below:
<img width="810" height="630" alt="flux_interaction_levels drawio" src="https://github.com/user-attachments/assets/b199db8e-e9bf-438e-8ce3-59ee7d4645e9" />
