### PR TITLE
fix job size for per-resource job requests

### DIFF
--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -207,9 +207,10 @@ static int px_init (flux_plugin_t *p,
     px->shell = shell;
 
     if (flux_shell_info_unpack (shell,
-                                "{s:I s:i}",
+                                "{s:I s:i s:i}",
                                 "jobid", &px->id,
-                                "rank", &px->shell_rank) < 0)
+                                "rank", &px->shell_rank,
+                                "ntasks", &px->total_nprocs) < 0)
         return -1;
     shell_debug ("jobid = %ju", (uintmax_t)px->id);
     shell_debug ("shell_rank = %d", px->shell_rank);
@@ -222,11 +223,6 @@ static int px_init (flux_plugin_t *p,
                                      &px->local_nprocs) < 0)
         return -1;
     shell_debug ("local_nprocs = %d", px->local_nprocs);
-    if (flux_shell_jobspec_info_unpack (shell,
-                                        "{s:i}",
-                                        "ntasks",
-                                        &px->total_nprocs) < 0)
-        return -1;
     shell_debug ("total_nprocs = %d", px->total_nprocs);
     if (!(px->job_tmpdir = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR")))
         return -1;

--- a/t/t0002-basic.t
+++ b/t/t0002-basic.t
@@ -73,6 +73,33 @@ test_expect_success '2n4p pmix.univ.size is set correctly' '
 			| sort -n >pmix.univ.size.out &&
 	test_cmp pmix.univ.size.exp pmix.univ.size.out
 '
+# issue #130: per-resource placement (--tasks-per-node) expands the task
+# count via a shell option, not the jobspec.  The job size must reflect the
+# expanded total; a stale value here previously broke MPI wireup.
+test_expect_success '2n4p pmix.job.size is correct with --tasks-per-node' '
+	cat >tpn.pmix.job.size.exp <<-EOT &&
+	0: 4
+	1: 4
+	2: 4
+	3: 4
+	EOT
+	run_timeout 30 flux run -N2 --tasks-per-node=2 \
+		${GETKEY} --proc=* --label-io pmix.job.size \
+			| sort -n >tpn.pmix.job.size.out &&
+	test_cmp tpn.pmix.job.size.exp tpn.pmix.job.size.out
+'
+test_expect_success '2n4p pmix.univ.size is correct with --tasks-per-node' '
+	cat >tpn.pmix.univ.size.exp <<-EOT &&
+	0: 4
+	1: 4
+	2: 4
+	3: 4
+	EOT
+	run_timeout 30 flux run -N2 --tasks-per-node=2 \
+		${GETKEY} --proc=* --label-io pmix.univ.size \
+			| sort -n >tpn.pmix.univ.size.out &&
+	test_cmp tpn.pmix.univ.size.exp tpn.pmix.univ.size.out
+'
 test_expect_success '2n3p pmix.local.size is set correctly' '
 	cat >2n3p.pmix.local.size.exp <<-EOT &&
 	0: 2

--- a/t/t1000-ompi-basic.t
+++ b/t/t1000-ompi-basic.t
@@ -49,6 +49,28 @@ test_expect_success '2n2p ompi hello' '
 # --env=OMPI_MCA_btl_base_verbose=100 \
 # --env=OMPI_MCA_btl_tcp_if_exclude=docker0,lo \
 
+# see issue #130
+# per-resource task placement (--tasks-per-node, --tasks-per-core) expands
+# the task count via a shell option rather than the jobspec, so the pmix
+# plugin must source the job size from shell info, not jobspec info.
+test_expect_success '1n2p ompi hello with --tasks-per-node' '
+	run_timeout 30 flux run -N1 --tasks-per-node=2 \
+		${MPI_HELLO} >hello_tpn_1n2p.out &&
+	grep "There are 2 tasks" hello_tpn_1n2p.out
+'
+
+test_expect_success '2n4p ompi hello with --tasks-per-node' '
+	run_timeout 30 flux run -N2 --tasks-per-node=2 \
+		${MPI_HELLO} >hello_tpn_2n4p.out &&
+	grep "There are 4 tasks" hello_tpn_2n4p.out
+'
+
+test_expect_success '1n2p ompi hello with --tasks-per-core' '
+	run_timeout 30 flux run -N1 --tasks-per-core=2 --cores=1 \
+		${MPI_HELLO} >hello_tpc_1n2p.out &&
+	grep "There are 2 tasks" hello_tpc_1n2p.out
+'
+
 # see issue #27
 test_expect_success '2n3p ompi hello doesnt hang' '
 	run_timeout 60 flux run -N2 -n3 \


### PR DESCRIPTION
Problem: OpenMPI jobs launched with `--tasks-per-node=N` or `--tasks-per-core=N`, `N>1` fail during `MPI_Init()` with "Failed to receive UCX worker address: Take next option (-46)".

Use `ntasks` from `flux_shell_info_unpack()` instead of `flux_shell_jobspec_info_unpack()`.  The latter doesn't include the per-resource multiplier and resulted in an incorrect value for PMIX_JOB_SIZE and PMIX_UNIV_SIZE, and a truncated PMIX_PROC_INFO_ARRAY.

Fixes #130