### PR TITLE
configure: check FLUX_PMIX_VERSION in AC_INIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# http://www.gnu.org/software/automake
+Makefile.in
+# http://www.gnu.org/software/autoconf
+/aclocal.m4
+/autom4te.cache/
+/config.status
+/configure
+/libtool
+.deps/
+.libs/
+
+# autoconf-preprocessed
+Makefile
+
+# Object files
+*.o
+# Libraries
+*.la
+*.lo
+
+# misc
+*.swp
+*.diff
+*.tar.gz
+*.orig
+*.core
+*.tap
+.coverage*
+*.trs
+*.log
+.dirstamp
+
+# coverage
+/flux-pmix-*-coverage.info
+/flux-pmix-*-coverage/
+*.gcno
+*.gcda
+
+# Rules to ignore auto-generated test harness scripts
+test_*.t
+

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,17 @@
+/compile
+/config.guess
+/config.h
+/config.h.in
+/config.sub
+/depcomp
+/install-sh
+/libtool.m4
+/ltmain.sh
+/ltoptions.m4
+/ltsugar.m4
+/ltversion.m4
+/lt~obsolete.m4
+/missing
+/stamp-h1
+/test-driver
+

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Prologue
 ##
 AC_INIT([flux-pmix],
-        m4_esyscmd([git describe --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
+        m4_esyscmd([test -n "$FLUX_PMIX_VERSION" && printf $FLUX_PMIX_VERSION || git describe --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS.md])

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,0 +1,5 @@
+/etc/rc.lua
+/sharness.d/00-setup.sh
+/test-results/
+/trash-directory.*
+

--- a/t/src/.gitignore
+++ b/t/src/.gitignore
@@ -1,0 +1,8 @@
+/abort
+/barrier
+/bizcard
+/getkey
+/mpi_version
+/notify
+/version
+


### PR DESCRIPTION
Problem: autogen.sh currently always fails if not run from a git repository because of the `git describe` command in `AC_INIT`

Check for and use a `FLUX_PMIX_VERSION` environment variable if defined, allowing the git command to be avoided.

This basically just copies the logic from `flux-core` and would be helpful in future for building from specific commits with tools like EasyBuild which prefer to download a tarball rather than use git.

Also creates and populates some initial `.gitignore` files in a separate commit.