### PR TITLE
plugin: parse config in shell init callback

### DIFF
--- a/src/shell/plugins/main.c
+++ b/src/shell/plugins/main.c
@@ -188,16 +188,53 @@ static int set_proc_infos (struct infovec *iv,
     return 0;
 }
 
+static bool member_of_csv (const char *list, const char *name)
+{
+    char *argz = NULL;
+    size_t argz_len;
+
+    if (argz_create_sep (list, ',', &argz, &argz_len) == 0) {
+        const char *entry = NULL;
+
+        while ((entry = argz_next (argz, argz_len, entry))) {
+            if (!strcmp (entry, name)) {
+                free (argz);
+                return true;
+            }
+        }
+        free (argz);
+    }
+    return false;
+}
+
 static int px_init (flux_plugin_t *p,
                     const char *topic,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
     flux_shell_t *shell = flux_plugin_get_shell (p);
+    const char *pmi_opt = NULL;
     struct px *px;
     int rc;
     pmix_info_t info[2];
     struct infovec *iv;
+
+    if (flux_shell_getopt_unpack (shell, "pmi", "s", &pmi_opt) < 0) {
+        shell_log_error ("pmi shell option must be a string");
+        return -1;
+    }
+    if (!pmi_opt || !member_of_csv (pmi_opt, "pmix"))
+        return 0; // plugin disabled
+
+    shell_debug ("server is enabled");
+
+    /* flux-pmix does not yet share hwloc with MPI, which forces MPI to
+     * go looking for it, sometimes at great cost to performance.
+     * Until we can address flux-framework/flux-pmix#31 properly,
+     * tell flux-core to share a hwloc xml file instead.
+     */
+    if (flux_shell_setopt_pack (shell, "hwloc", "{s:i}", "xmlfile", 1) < 0)
+        shell_warn ("unable to set Flux hwloc.xmlfile shell option");
 
     if (!(px = calloc (1, sizeof (*px)))
         || flux_plugin_aux_set (p, "px", px, (flux_free_f)px_destroy) < 0) {
@@ -325,8 +362,9 @@ static int px_task_init (flux_plugin_t *p,
     int rank;
     int rc;
 
+    if (!(px = flux_plugin_aux_get (p, "px")))
+        return 0; // plugin disabled
     if (!(shell = flux_plugin_get_shell (p))
-        || !(px = flux_plugin_aux_get (p, "px"))
         || !(task = flux_shell_current_task (shell))
         || !(cmd = flux_shell_task_cmd (task))
         || flux_shell_task_info_unpack (task, "{s:i}", "rank", &rank) < 0)
@@ -381,52 +419,10 @@ static int px_task_init (flux_plugin_t *p,
     return 0;
 }
 
-static bool member_of_csv (const char *list, const char *name)
-{
-    char *argz = NULL;
-    size_t argz_len;
-
-    if (argz_create_sep (list, ',', &argz, &argz_len) == 0) {
-        const char *entry = NULL;
-
-        while ((entry = argz_next (argz, argz_len, entry))) {
-            if (!strcmp (entry, name)) {
-                free (argz);
-                return true;
-            }
-        }
-        free (argz);
-    }
-    return false;
-}
-
 int flux_plugin_init (flux_plugin_t *p)
 {
-    const char *pmi_opt = NULL;
-    flux_shell_t *shell;
-
-    if (!(shell = flux_plugin_get_shell (p))
-        || flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME) < 0)
-        return -1;
-
-    if (flux_shell_getopt_unpack (shell, "pmi", "s", &pmi_opt) < 0) {
-        shell_log_error ("pmi shell option must be a string");
-        return -1;
-    }
-    if (!pmi_opt || !member_of_csv (pmi_opt, "pmix"))
-        return 0; // plugin disabled
-
-    shell_debug ("server is enabled");
-
-    /* flux-pmix does not yet share hwloc with MPI, which forces MPI to
-     * go looking for it, sometimes at great cost to performance.
-     * Until we can address flux-framework/flux-pmix#31 properly,
-     * tell flux-core to share a hwloc xml file instead.
-     */
-    if (flux_shell_setopt_pack (shell, "hwloc", "{s:i}", "xmlfile", 1) < 0)
-        shell_warn ("unable to set Flux hwloc.xmlfile shell option");
-
-    if (flux_plugin_add_handler (p, "shell.init", px_init, NULL) < 0
+    if (flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME) < 0
+        || flux_plugin_add_handler (p, "shell.init", px_init, NULL) < 0
         || flux_plugin_add_handler (p, "task.init",  px_task_init, NULL) < 0) {
         return -1;
     }


### PR DESCRIPTION
Problem: the pmix shell plugin parses its configuration too early

Move config parsing from flux_plugin_init() to px_init()

Closes #134 (and https://github.com/flux-framework/flux-core/pull/7747)